### PR TITLE
Add hip clang install to install script

### DIFF
--- a/install
+++ b/install
@@ -15,6 +15,7 @@ function display_help()
     #    echo "    [-d|--dependencies] install build dependencies"
     echo "    [-c|--clients] build library clients too (combines with -i & -d)"
     echo "    [-g|--debug] -DCMAKE_BUILD_TYPE=Debug (default is =Release)"
+    echo "    [--hip-clang] build library for amdgpu backend using hip-clang"
 }
 
 
@@ -25,6 +26,7 @@ install_package=false
 build_package=false
 build_clients=false
 build_release=true
+build_hip_clang=false
 run_tests=false
 rocm_path=/opt/rocm/bin
 # #################################################
@@ -34,7 +36,7 @@ rocm_path=/opt/rocm/bin
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,test,package --options hicdtp -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,debug,hip-clang,test,package --options hicdtp -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -69,6 +71,9 @@ while true; do
 	-t|--test)
 	    run_tests=true
 	    shift ;;
+	--hip-clang)
+	    build_hip_clang=true
+	    shift ;;
 	--) shift ; break ;;
 	*)  echo "Unexpected command line parameter received; aborting";
 	    exit 1
@@ -100,8 +105,12 @@ fi
 # before 'cmake' or setting cmake option 'CMAKE_CXX_COMPILER' to path to the HCC compiler.
 #
 
+compiler="hcc"
+if [[ "${build_hip_clang}" == true ]]; then
+    compiler="hipcc"
+fi
 
-CXX=$rocm_path/hcc cmake -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
+CXX=$rocm_path/${compiler} cmake -DBUILD_BENCHMARK=ON ../../. # or cmake-gui ../.
 
 # Build
 make -j$(nproc)


### PR DESCRIPTION
Adding the HIP-Clang path which uses hipcc to compile rocThrust instead.