### PR TITLE
Hip math functions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,12 +56,26 @@ rocThrustCI:
     {
         platform, project->
 
-        def command = """#!/usr/bin/env bash
-                set -x
-                cd ${project.paths.project_build_prefix}/build
-                make -j4
-                ctest --output-on-failure
-            """
+        def command
+        
+        if(platform.jenkinsLabel.contains('centos'))
+        {
+            command = """#!/usr/bin/env bash
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release
+                    make -j4
+                    sudo ctest --output-on-failure
+                """
+        }
+        else
+        {
+            command = """#!/usr/bin/env bash
+                    set -x
+                    cd ${project.paths.project_build_prefix}/build/release
+                    make -j4
+                    ctest --output-on-failure
+                """
+        }
 
         platform.runCommand(this, command)
     }

--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -135,7 +135,7 @@ using ::isfinite;
 
 #    endif // CUDA_VERSION
 
-#    else
+#  else
 
 #    ifdef __HIP_DEVICE_COMPILE__
 
@@ -154,9 +154,9 @@ using std::isinf;
 using std::isnan;
 using std::signbit;
 using std::isfinite;
-#endif // __HIP_COMPILER__
+#    endif // __HIP_COMPILER__
 
-#endif // __CUDACC__
+#  endif // __CUDACC__
 
 using ::atanh;
 #endif // _MSC_VER

--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -124,7 +124,7 @@ __host__ __device__ inline int isfinite(double x){
 // sometimes the CUDA toolkit provides these these names as macros,
 // sometimes functions in the global scope
 
-#    if (CUDA_VERSION >= 6500 )
+#    if (CUDA_VERSION >= 6500)
 using ::isinf;
 using ::isnan;
 using ::signbit;

--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -124,7 +124,7 @@ __host__ __device__ inline int isfinite(double x){
 // sometimes the CUDA toolkit provides these these names as macros,
 // sometimes functions in the global scope
 
-#    if (CUDA_VERSION >= 6500)
+#    if (CUDA_VERSION >= 6500 )
 using ::isinf;
 using ::isnan;
 using ::signbit;
@@ -136,6 +136,14 @@ using ::isfinite;
 #    endif // CUDA_VERSION
 
 #  else
+
+# ifdef __HIP_DEVICE_COMPILE__
+ using ::isinf;
+ using ::isnan;
+ using ::signbit;
+ using ::isfinite;
+# else
+
 // Some compilers do not provide these in the global scope
 // they are in std:: instead
 // Since we're not compiling with nvcc, it's safe to use the functions in std::
@@ -143,7 +151,9 @@ using std::isinf;
 using std::isnan;
 using std::signbit;
 using std::isfinite;
-#  endif // __CUDACC__
+#endif // __HIP_COMPILER__
+
+#endif // __CUDACC__
 
 using ::atanh;
 #endif // _MSC_VER

--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -135,14 +135,17 @@ using ::isfinite;
 
 #    endif // CUDA_VERSION
 
-#  else
+#    else
 
-# ifdef __HIP_DEVICE_COMPILE__
- using ::isinf;
- using ::isnan;
- using ::signbit;
- using ::isfinite;
-# else
+#    ifdef __HIP_DEVICE_COMPILE__
+
+// hip_runtime.h provides these functions in the global scope
+using ::isinf;
+using ::isnan;
+using ::signbit;
+using ::isfinite;
+
+#    else
 
 // Some compilers do not provide these in the global scope
 // they are in std:: instead


### PR DESCRIPTION
fixing math function calls to use hip functions present in the global namespace instead of std:: functions from cmath.