### PR TITLE
Packaging fix for hip-clang

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,7 @@ rocThrustCI:
         }
         else if(platform.jenkinsLabel.contains('hip-clang'))
         {
-            platform.runCommand(this, null)
+            packageCommand = null
         }
         else
         {


### PR DESCRIPTION
set packaging command to null instead of passing null into the runCommand function. This results in the build failing. Please merge into develop ASAP.