### PR TITLE
Uncomment the headers necessary for PyTorch build.

### DIFF
--- a/thrust/system/hip/execution_policy.h
+++ b/thrust/system/hip/execution_policy.h
@@ -36,7 +36,7 @@
 
 // pass
 // ----------------
-//#include <thrust/system/hip/detail/adjacent_difference.h>
+#include <thrust/system/hip/detail/adjacent_difference.h>
 #include <thrust/system/hip/detail/copy.h>
 #include <thrust/system/hip/detail/copy_if.h>
 #include <thrust/system/hip/detail/count.h>
@@ -78,7 +78,7 @@
 #include <thrust/system/hip/detail/binary_search.h>
 #include <thrust/system/hip/detail/merge.h>
 #include <thrust/system/hip/detail/scan_by_key.h>
-// #include <thrust/system/hip/detail/set_operations.h>
+#include <thrust/system/hip/detail/set_operations.h>
 #include <thrust/system/hip/detail/sort.h>
 
 /*! \file thrust/system/hip/execution_policy.h


### PR DESCRIPTION
I just found that two headers are necessary to get PyTorch build passed but have no idea why that two headers are commented out. Let me whether you have concern to re-enable them.