### PR TITLE
Workaround for hipclang

### DIFF
--- a/thrust/system/hip/config.h
+++ b/thrust/system/hip/config.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2020, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -36,12 +36,12 @@
 #define THRUST_UNUSED_VAR(expr) do { (void)(expr); } while (0)
 
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_HCC
-    #ifdef __HIP_DEVICE_COMPILE__
+    #ifndef __HIP_DEVICE_COMPILE__
+        #define __THRUST_HAS_HIPRT__ 1
+        #define THRUST_HIP_RUNTIME_FUNCTION __host__ __device__ __forceinline__
+    #else
         #define __THRUST_HAS_HIPRT__ 0
         #define THRUST_HIP_RUNTIME_FUNCTION __host__ __forceinline__
-    #else
-        #define __THRUST_HAS_HIPRT__ 1
-        #define THRUST_HIP_RUNTIME_FUNCTION __host__ __device__  __forceinline__
     #endif
 #else
     #define __THRUST_HAS_HIPRT__ 0

--- a/thrust/system/hip/config.h
+++ b/thrust/system/hip/config.h
@@ -41,7 +41,7 @@
         #define THRUST_HIP_RUNTIME_FUNCTION __host__ __forceinline__
     #else
         #define __THRUST_HAS_HIPRT__ 1
-        #define THRUST_HIP_RUNTIME_FUNCTION __host__ __forceinline__
+        #define THRUST_HIP_RUNTIME_FUNCTION __host__ __device__  __forceinline__
     #endif
 #else
     #define __THRUST_HAS_HIPRT__ 0

--- a/thrust/system/hip/detail/sort.h
+++ b/thrust/system/hip/detail/sort.h
@@ -381,37 +381,36 @@ stable_sort(execution_policy<Derived>& policy,
 {
     struct workaround
     {
-              __host__
-	      static void par(execution_policy<Derived>& policy,
-			      ItemsIt                    first,
-			      ItemsIt                    last,
-			      CompareOp                  compare_op)
-      {
-#if __HCC__ && __HIP_DEVICE_COMPILE__
-	THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-        (__smart_sort::smart_sort<detail::false_type, Derived, ItemsIt, ItemsIt, CompareOp>)
-    );
-#else
-	typedef typename thrust::iterator_value<ItemsIt>::type item_type;
-	__smart_sort::smart_sort<detail::false_type>(
-						     policy, first, last, (item_type*)NULL, compare_op
-						     );
-#endif	
-      }
+        __host__
+        static void par(execution_policy<Derived>& policy,
+                        ItemsIt                    first,
+                        ItemsIt                    last,
+                        CompareOp                  compare_op)
+        {
+        #if __HCC__ && __HIP_DEVICE_COMPILE__
+        THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
+            (__smart_sort::smart_sort<detail::false_type, Derived, ItemsIt, ItemsIt, CompareOp>)
+        );
+        #else
+        typedef typename thrust::iterator_value<ItemsIt>::type item_type;
+        __smart_sort::smart_sort<detail::false_type>(
+                                 policy, first, last, (item_type*)NULL, compare_op
+                                 );
+        #endif
+        }
         __device__
-	static void seq(execution_policy<Derived>& policy,
-			ItemsIt                    first,
-			ItemsIt                    last,
-			CompareOp                  compare_op)
-      {
-	thrust::stable_sort(cvt_to_seq(derived_cast(policy)), first, last, compare_op);
-	
-      }
+        static void seq(execution_policy<Derived>& policy,
+                ItemsIt                    first,
+                ItemsIt                    last,
+                CompareOp                  compare_op)
+        {
+            thrust::stable_sort(cvt_to_seq(derived_cast(policy)), first, last, compare_op);
+        }
     };
-     #if __THRUST_HAS_HIPRT__
-      workaround::par(policy, first, last, compare_op);
+    #if __THRUST_HAS_HIPRT__
+        workaround::par(policy, first, last, compare_op);
     #else
-      workaround::seq(policy, first, last, compare_op);
+        workaround::seq(policy, first, last, compare_op);
     #endif
 }
 
@@ -438,34 +437,33 @@ stable_sort_by_key(execution_policy<Derived>& policy,
 {
     struct workaround
     {
-      __host__
-      static void par(execution_policy<Derived>& policy,
-		      KeysIt                     keys_first,
-		      KeysIt                     keys_last,
-		      ValuesIt                   values,
-		      CompareOp                  compare_op)
-	
-      {
-#if __HCC__ && __HIP_DEVICE_COMPILE__
- THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-       (__smart_sort::smart_sort<detail::true_type, Derived, KeysIt, ValuesIt, CompareOp>)
-   );
- #else
-	__smart_sort::smart_sort<detail::true_type>(
-						    policy, keys_first, keys_last, values, compare_op);
-#endif
-      }
+        __host__
+        static void par(execution_policy<Derived>& policy,
+                        KeysIt                     keys_first,
+                        KeysIt                     keys_last,
+                        ValuesIt                   values,
+                        CompareOp                  compare_op)
+        {
+            #if __HCC__ && __HIP_DEVICE_COMPILE__
+             THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
+                   (__smart_sort::smart_sort<detail::true_type, Derived, KeysIt, ValuesIt, CompareOp>)
+               );
+             #else
+            __smart_sort::smart_sort<detail::true_type>(
+                            policy, keys_first, keys_last, values, compare_op);
+            #endif
+        }
+
         __device__
-	static void seq(execution_policy<Derived>& policy,
-			KeysIt                     keys_first,
-			KeysIt                     keys_last,
-			ValuesIt                   values,
-			CompareOp                  compare_op)
-	  
-      {
-	thrust::stable_sort_by_key(
-				   cvt_to_seq(derived_cast(policy)), keys_first, keys_last, values, compare_op);
-      }
+        static void seq(execution_policy<Derived>& policy,
+            KeysIt                     keys_first,
+            KeysIt                     keys_last,
+            ValuesIt                   values,
+            CompareOp                  compare_op)
+        {
+        thrust::stable_sort_by_key(
+                   cvt_to_seq(derived_cast(policy)), keys_first, keys_last, values, compare_op);
+        }
     };
 
     #if __THRUST_HAS_HIPRT__
@@ -473,7 +471,6 @@ stable_sort_by_key(execution_policy<Derived>& policy,
     #else
     workaround::seq(policy, keys_first, keys_last, values, compare_op);
     #endif
-  
 }
 
 __thrust_exec_check_disable__ template <class Derived,

--- a/thrust/system/hip/detail/sort.h
+++ b/thrust/system/hip/detail/sort.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright© 2019 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright© 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -379,17 +379,40 @@ stable_sort(execution_policy<Derived>& policy,
             ItemsIt                    last,
             CompareOp                  compare_op)
 {
-    THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
+    struct workaround
+    {
+              __host__
+	      static void par(execution_policy<Derived>& policy,
+			      ItemsIt                    first,
+			      ItemsIt                    last,
+			      CompareOp                  compare_op)
+      {
+#if __HCC__ && __HIP_DEVICE_COMPILE__
+	THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
         (__smart_sort::smart_sort<detail::false_type, Derived, ItemsIt, ItemsIt, CompareOp>)
     );
-#if __THRUST_HAS_HIPRT__
-    typedef typename thrust::iterator_value<ItemsIt>::type item_type;
-    __smart_sort::smart_sort<detail::false_type>(
-        policy, first, last, (item_type*)NULL, compare_op
-    );
 #else
-    thrust::stable_sort(cvt_to_seq(derived_cast(policy)), first, last, compare_op);
-#endif
+	typedef typename thrust::iterator_value<ItemsIt>::type item_type;
+	__smart_sort::smart_sort<detail::false_type>(
+						     policy, first, last, (item_type*)NULL, compare_op
+						     );
+#endif	
+      }
+        __device__
+	static void seq(execution_policy<Derived>& policy,
+			ItemsIt                    first,
+			ItemsIt                    last,
+			CompareOp                  compare_op)
+      {
+	thrust::stable_sort(cvt_to_seq(derived_cast(policy)), first, last, compare_op);
+	
+      }
+    };
+     #if __THRUST_HAS_HIPRT__
+      workaround::par(policy, first, last, compare_op);
+    #else
+      workaround::seq(policy, first, last, compare_op);
+    #endif
 }
 
 __thrust_exec_check_disable__ template <class Derived, class ItemsIt, class CompareOp>
@@ -413,18 +436,44 @@ stable_sort_by_key(execution_policy<Derived>& policy,
                    ValuesIt                   values,
                    CompareOp                  compare_op)
 {
-    THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-        (__smart_sort::smart_sort<detail::true_type, Derived, KeysIt, ValuesIt, CompareOp>)
-    );
-#if __THRUST_HAS_HIPRT__
-    __smart_sort::smart_sort<detail::true_type>(
-        policy, keys_first, keys_last, values, compare_op
-    );
-#else
-    thrust::stable_sort_by_key(
-        cvt_to_seq(derived_cast(policy)), keys_first, keys_last, values, compare_op
-    );
+    struct workaround
+    {
+      __host__
+      static void par(execution_policy<Derived>& policy,
+		      KeysIt                     keys_first,
+		      KeysIt                     keys_last,
+		      ValuesIt                   values,
+		      CompareOp                  compare_op)
+	
+      {
+#if __HCC__ && __HIP_DEVICE_COMPILE__
+ THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
+       (__smart_sort::smart_sort<detail::true_type, Derived, KeysIt, ValuesIt, CompareOp>)
+   );
+ #else
+	__smart_sort::smart_sort<detail::true_type>(
+						    policy, keys_first, keys_last, values, compare_op);
 #endif
+      }
+        __device__
+	static void seq(execution_policy<Derived>& policy,
+			KeysIt                     keys_first,
+			KeysIt                     keys_last,
+			ValuesIt                   values,
+			CompareOp                  compare_op)
+	  
+      {
+	thrust::stable_sort_by_key(
+				   cvt_to_seq(derived_cast(policy)), keys_first, keys_last, values, compare_op);
+      }
+    };
+
+    #if __THRUST_HAS_HIPRT__
+    workaround::par(policy, keys_first, keys_last, values, compare_op);
+    #else
+    workaround::seq(policy, keys_first, keys_last, values, compare_op);
+    #endif
+  
 }
 
 __thrust_exec_check_disable__ template <class Derived,
@@ -473,7 +522,7 @@ sort_by_key(execution_policy<Derived>& policy,
 }
 
 template <class Derived, class KeysIt, class ValuesIt>
-void THRUST_HIP_FUNCTION
+void THRUST_HIP_HOST_FUNCTION
 stable_sort_by_key(execution_policy<Derived>& policy,
                    KeysIt                     keys_first,
                    KeysIt                     keys_last,

--- a/thrust/system/hip/detail/sort.h
+++ b/thrust/system/hip/detail/sort.h
@@ -379,6 +379,8 @@ stable_sort(execution_policy<Derived>& policy,
             ItemsIt                    last,
             CompareOp                  compare_op)
 {
+    // struct workaround is required for HIP-clang
+    // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
     struct workaround
     {
         __host__
@@ -408,9 +410,9 @@ stable_sort(execution_policy<Derived>& policy,
         }
     };
     #if __THRUST_HAS_HIPRT__
-        workaround::par(policy, first, last, compare_op);
+    workaround::par(policy, first, last, compare_op);
     #else
-        workaround::seq(policy, first, last, compare_op);
+    workaround::seq(policy, first, last, compare_op);
     #endif
 }
 
@@ -435,6 +437,8 @@ stable_sort_by_key(execution_policy<Derived>& policy,
                    ValuesIt                   values,
                    CompareOp                  compare_op)
 {
+    // struct workaround is required for HIP-clang
+    // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
     struct workaround
     {
         __host__

--- a/thrust/system/hip/detail/sort.h
+++ b/thrust/system/hip/detail/sort.h
@@ -522,7 +522,7 @@ sort_by_key(execution_policy<Derived>& policy,
 }
 
 template <class Derived, class KeysIt, class ValuesIt>
-void THRUST_HIP_HOST_FUNCTION
+void THRUST_HIP_FUNCTION
 stable_sort_by_key(execution_policy<Derived>& policy,
                    KeysIt                     keys_first,
                    KeysIt                     keys_last,


### PR DESCRIPTION
This copies the workaround from parallel_for.h to sort.h. It appears to be needed for the hipclang compiler.