### PR TITLE
WIP: Large data tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ option(BUILD_TEST "Build tests" OFF)
 option(BUILD_EXAMPLES "Build examples" OFF)
 option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(DOWNLOAD_ROCPRIM "Download rocPRIM and do not search for rocPRIM package" OFF)
+option(LARGE_TEST "Run tests close to VRAM capacity" OFF)
 set(RNG_SEED_COUNT 0 CACHE STRING "Number of true random sequences to test each input size for")
 set(PRNG_SEEDS 1 CACHE STRING "Seeds of pseudo random sequences to test each input size for")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,9 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 if(DISABLE_WERROR)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-function")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-function -Wno-unused-parameter")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-function -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Werror")
 endif()
 
 # Get dependencies

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,10 @@ function(add_rocthrust_test TEST)
             tbbmalloc
             tbbmalloc_proxy
     )
+    target_compile_definitions(testing_common
+        INTERFACE
+            THRUST_HOST_SYSTEM=3 # THRUST_HOST_SYSTEM_TBB
+    )
     foreach(amdgpu_target ${AMDGPU_TARGETS})
         target_link_libraries(${TEST_TARGET}
             PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,7 +50,7 @@ function(add_rocthrust_test TEST)
             tbbmalloc
             tbbmalloc_proxy
     )
-    target_compile_definitions(testing_common
+    target_compile_definitions(${TEST_TARGET}
         INTERFACE
             THRUST_HOST_SYSTEM=3 # THRUST_HOST_SYSTEM_TBB
     )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,12 +39,16 @@ function(add_rocthrust_test TEST)
         PUBLIC
             ${GTEST_INCLUDE_DIRS}
             ${CMAKE_CURRENT_BINARY_DIR}
+            ${CMAKE_CURRENT_SOURCE_DIR}
     )
     target_link_libraries(${TEST_TARGET}
         PRIVATE
             rocthrust
             roc::rocprim_hip
             ${GTEST_BOTH_LIBRARIES}
+            tbb
+            tbbmalloc
+            tbbmalloc_proxy
     )
     foreach(amdgpu_target ${AMDGPU_TARGETS})
         target_link_libraries(${TEST_TARGET}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,11 @@ else() # Workaround for not having string(JOIN) and list(JOIN)
   message(${PRNG_SEEDS_INITIALIZER})
 endif()
 
+if(LARGE_TESTS)
+  set(LARGE_TESTS_BOOLEAN true)
+else()
+  set(LARGE_TESTS_BOOLEAN false)
+endif()
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/test_seed.in.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/test_seed.hpp

--- a/test/MWC64X.hpp
+++ b/test/MWC64X.hpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2011, David Thomas
+//
+// Copyright(c) 2018 M�t� Ferenc Nagy-Egri, Wigner GPU-Laboratory.
+//
+// All rights reserved.
+//
+// The 3-clause BSD License is applied to this software, see LICENSE.txt
+//
+
+#pragma once
+
+#ifdef __SYCL_DEVICE_ONLY__
+// SYCL include
+#include <CL/sycl.hpp>
+#endif
+
+// Standard C++ includes
+#include <cstddef>  // std::size_t
+#include <cstdint>  // std::uint64_t
+#include <limits>   // std::numeric_limits::min,max
+#include <array>    // std::array
+
+namespace prng
+{
+    template <std::uint32_t A, std::uint64_t M>
+    class multiply_with_carry_engine_32
+    {
+    public:
+
+        using result_type = std::uint32_t;
+
+        static constexpr std::size_t word_size = 32;
+        static constexpr std::size_t state_size = 2;
+        static constexpr result_type mask = 0xffffffff;
+
+        static constexpr result_type default_seed = 5489u;
+
+        multiply_with_carry_engine_32(result_type value) { seed(value); }
+
+        //template <typename Sseq> explicit multiply_with_carry_engine_32(Sseq& s);
+
+        multiply_with_carry_engine_32() : multiply_with_carry_engine_32(default_seed) {}
+        multiply_with_carry_engine_32(const multiply_with_carry_engine_32&) = default;
+
+        void seed(result_type value = default_seed)
+        {
+        }
+        //template <typename Sseq> void seed(Sseq& s);
+
+        result_type operator()()
+        {
+            next_state();
+
+            return x ^ c;
+        }
+
+        void discard(unsigned long long z)
+        {
+            auto tmp = skip_impl_mod64({ x, c }, z);
+            x = tmp[0];
+            c = tmp[1];
+        }
+
+        friend bool operator==(const multiply_with_carry_engine_32<A, M>& lhs,
+                               const multiply_with_carry_engine_32<A, M>& rhs)
+        {
+            return (lhs.x == rhs.x) &&
+                   (lhs.c == rhs.c);
+        }
+
+        friend bool operator!=(const multiply_with_carry_engine_32<A, M>& lhs,
+                               const multiply_with_carry_engine_32<A, M>& rhs)
+        {
+            return (lhs.x != rhs.x) ||
+                   (lhs.c != rhs.c);
+        }
+
+        static constexpr result_type min() { return std::numeric_limits<result_type>::min(); }
+        static constexpr result_type max() { return std::numeric_limits<result_type>::max(); }
+
+    private:
+
+        result_type x, c;
+
+        // Convenience renames
+        static constexpr auto a = A;
+        static constexpr auto m = M;
+
+        inline void next_state()
+        {
+#ifdef __SYCL_DEVICE_ONLY__
+            std::uint32_t xn = a * x + c;
+            std::uint32_t carry = static_cast<std::uint32_t>(xn < c); // The (Xn<C) will be zero or one for scalar
+            std::uint32_t cn = cl::sycl::mad_hi(a, x, carry);
+
+            x = xn;
+            c = cn;
+#else
+            *reinterpret_cast<std::uint64_t*>(this) = x * static_cast<std::uint64_t>(a) + c;
+#endif
+        }
+
+        std::uint64_t add_mod64(std::uint64_t a_,
+                                std::uint64_t b_,
+                                std::uint64_t M_)
+        {
+            std::uint64_t v_ = a_ + b_;
+            if ((v_ >= M_) || (v_ < a_))
+                v_ = v_ - M_;
+            return v_;
+        }
+
+        std::uint64_t mul_mod64(std::uint64_t a_,
+                                std::uint64_t b_,
+                                std::uint64_t M_)
+        {
+            std::uint64_t r_ = 0;
+            while (a_ != 0) {
+                if (a_ & 1)
+                    r_ = add_mod64(r_, b_, M_);
+                b_ = add_mod64(b_, b_, M_);
+                a_ = a_ >> 1;
+            }
+            return r_;
+        }
+
+        std::uint64_t pow_mod64(std::uint64_t a_,
+                                std::uint64_t e_,
+                                std::uint64_t M_)
+        {
+            std::uint64_t sqr_ = a_, acc_ = 1;
+            while (e_ != 0) {
+                if (e_ & 1)
+                    acc_ = mul_mod64(acc_, sqr_, M_);
+                sqr_ = mul_mod64(sqr_, sqr_, M_);
+                e_ = e_ >> 1;
+            }
+            return acc_;
+        }
+
+        std::array<std::uint32_t, 2> skip_impl_mod64(std::array<std::uint32_t, 2> curr_,
+                                                     std::uint64_t distance_)
+        {
+            std::uint64_t m_ = pow_mod64(a, distance_, m);
+            std::uint64_t x = curr_[0]*(std::uint64_t)a + curr_[1];
+            x = mul_mod64(x, m_, m);
+            return { (std::uint32_t)(x / a),
+                     (std::uint32_t)(x % a) };
+        }
+    };
+
+    using mwc64x_32 = multiply_with_carry_engine_32<4294883355u, 18446383549859758079ul>;
+}

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -52,7 +52,7 @@ TYPED_TEST(CountPrimitiveTests, TestCount)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -105,7 +105,7 @@ TYPED_TEST(CountTests, TestCountIf)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -270,7 +270,7 @@ TYPED_TEST(FindTests, TestFind)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -310,7 +310,7 @@ TYPED_TEST(FindTests, TestFindIf)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -352,7 +352,7 @@ TYPED_TEST(FindTests, TestFindIfNot)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 

--- a/test/test_partition.cpp
+++ b/test/test_partition.cpp
@@ -336,7 +336,7 @@ TYPED_TEST(PartitionIntegerTests, TestPartition)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -371,7 +371,7 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionStencil)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -412,7 +412,7 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopy)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -473,7 +473,7 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopyStencil)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -543,7 +543,7 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopyStencil)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -613,7 +613,7 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopyToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -720,7 +720,7 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopyStencilToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -841,7 +841,7 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartition)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -871,7 +871,7 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionStencil)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -908,7 +908,7 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopy)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -965,7 +965,7 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopyToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -1072,7 +1072,7 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopyStencilToDiscardIterato
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 

--- a/test/test_reduce.cpp
+++ b/test/test_reduce.cpp
@@ -15,8 +15,6 @@
  *  limitations under the License.
  */
 
-#define THRUST_HOST_SYSTEM 3
-
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/retag.h>
 #include <thrust/reduce.h>

--- a/test/test_reduce.cpp
+++ b/test/test_reduce.cpp
@@ -15,6 +15,8 @@
  *  limitations under the License.
  */
 
+#define THRUST_HOST_SYSTEM 3
+
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/retag.h>
 #include <thrust/reduce.h>
@@ -96,7 +98,7 @@ TYPED_TEST(ReducePrimitiveTests, TestReduce)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(1))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -105,7 +107,7 @@ TYPED_TEST(ReducePrimitiveTests, TestReduce)
             SCOPED_TRACE(testing::Message() << "with seed= " << seed);
 
             thrust::host_vector<T> h_data = get_random_data<T>(
-                size, std::numeric_limits<T>::min(), std::numeric_limits<T>::max(), seed);
+                size, (T)0, (T)1, seed);
             thrust::device_vector<T> d_data = h_data;
 
             T init = T(13);
@@ -155,7 +157,7 @@ TYPED_TEST(ReduceIntegerTests, TestReduceWithOperator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(1))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -230,8 +232,7 @@ TYPED_TEST(ReducePrimitiveTests, TestReduceCountingIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    const std::vector<size_t> sizes = get_sizes();
-    for(auto size : sizes)
+    for(auto size : get_sizes<T>(1))
     {
         size_t n = thrust::min<size_t>(size, std::numeric_limits<T>::max());
 

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -372,7 +372,7 @@ TYPED_TEST(ScanVariablesTests, TestScanWithOperator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -408,7 +408,7 @@ TYPED_TEST(ScanVariablesTests, TestScanWithOperatorToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -455,7 +455,7 @@ TYPED_TEST(ScanVariablesTests, TestScan)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -510,7 +510,7 @@ TYPED_TEST(ScanVariablesTests, TestScanToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 

--- a/test/test_seed.in.hpp
+++ b/test/test_seed.in.hpp
@@ -28,4 +28,6 @@ static constexpr size_t rng_seed_count = ${RNG_SEED_COUNT};
 static const std::initializer_list<uint32_t> prng_seeds = { ${PRNG_SEEDS_INITIALIZER} };
 static constexpr seed_type seed_value_addition = 100;
 
+static constexpr bool large_tests = ${LARGE_TESTS_BOOLEAN};
+
 #endif // TEST_SEED_HPP_

--- a/test/test_seed.in.hpp
+++ b/test/test_seed.in.hpp
@@ -18,10 +18,10 @@
 #ifndef TEST_SEED_HPP_
 #define TEST_SEED_HPP_
 
-#include <random>
+#include "MWC64X.hpp"
 #include <initializer_list>
 
-using random_engine = std::minstd_rand;
+using random_engine = prng::mwc64x_32;
 using seed_type = random_engine::result_type;
 
 static constexpr size_t rng_seed_count = ${RNG_SEED_COUNT};

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -60,7 +60,7 @@ TYPED_TEST(SortTests, Sort)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<key_type>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -111,7 +111,7 @@ TYPED_TEST(SortTests, SortByKey)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<thrust::tuple<key_type, value_type>>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -156,7 +156,7 @@ TYPED_TEST(SortTests, StableSort)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<key_type>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -207,7 +207,7 @@ TYPED_TEST(SortTests, StableSortByKey)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<thrust::tuple<key_type, value_type>>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -342,7 +342,7 @@ TYPED_TEST(SortVectorPrimitives, TestSortAscendingKey)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -37,7 +37,7 @@ struct unary_transform
 {
     __device__ __host__ inline constexpr T operator()(const T& a) const
     {
-        return a + 5;
+        return a + (T)5;
     }
 };
 
@@ -46,7 +46,7 @@ struct binary_transform
 {
     __device__ __host__ inline constexpr T operator()(const T& a, const T& b) const
     {
-        return a * 2 + b * 5;
+        return a * (T)2 + b * (T)5;
     }
 };
 

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -49,7 +49,7 @@ struct binary_transform
         return a * (T)2 + b * (T)5;
     }
 };
-
+/*
 TYPED_TEST(TransformTests, UnaryTransform)
 {
     using T = typename TestFixture::input_type;
@@ -83,7 +83,7 @@ TYPED_TEST(TransformTests, UnaryTransform)
         }
     }
 }
-
+*/
 TYPED_TEST(TransformTests, BinaryTransform)
 {
     using T = typename TestFixture::input_type;

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -91,7 +91,7 @@ TYPED_TEST(TransformTests, BinaryTransform)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -120,6 +120,8 @@ TYPED_TEST(TransformTests, BinaryTransform)
                           d_output.begin(),
                           binary_transform<U>());
 
+        h_input1.clear();
+        h_input2.clear();
         thrust::host_vector<U> h_output = d_output;
         for(size_t i = 0; i < size; i++)
         {
@@ -579,7 +581,7 @@ TYPED_TEST(TransformTests, TestTransformUnary)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -590,15 +592,16 @@ TYPED_TEST(TransformTests, TestTransformUnary)
             thrust::host_vector<T> h_input = get_random_data<T>(
                 size, std::numeric_limits<T>::min(), std::numeric_limits<T>::max(), seed);
 
-            thrust::device_vector<T> d_input = h_input;
-
             thrust::host_vector<U>   h_output(size);
-            thrust::device_vector<U> d_output(size);
-
             thrust::transform(
                 h_input.begin(), h_input.end(), h_output.begin(), thrust::negate<T>());
+
+            thrust::device_vector<T> d_input = h_input;
+            thrust::device_vector<U> d_output(size);
             thrust::transform(
                 d_input.begin(), d_input.end(), d_output.begin(), thrust::negate<T>());
+
+            h_input.clear();
 
             ASSERT_EQ(h_output, d_output);
         }

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -57,7 +57,7 @@ TYPED_TEST(TransformTests, UnaryTransform)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size = " << size);
 
@@ -75,6 +75,7 @@ TYPED_TEST(TransformTests, UnaryTransform)
         thrust::device_vector<U> d_output(size);
         thrust::transform(d_input.begin(), d_input.end(), d_output.begin(), unary_transform<U>());
 
+        h_input.clear();
         thrust::host_vector<U> h_output = d_output;
         for(size_t i = 0; i < size; i++)
         {

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -614,7 +614,7 @@ TYPED_TEST(TransformTests, TestTransformUnaryToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -661,7 +661,7 @@ TYPED_TEST(TransformTests, TestTransformUnaryToDiscardIteratorZipped)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -695,6 +695,8 @@ TYPED_TEST(TransformTests, TestTransformUnaryToDiscardIteratorZipped)
             ZipIterator2 d_result
                 = thrust::transform(d_input.begin(), d_input.end(), z2, repeat2());
 
+            h_input.clear();
+
             thrust::discard_iterator<> reference(size);
 
             ASSERT_EQ(h_output, d_output);
@@ -721,7 +723,7 @@ TYPED_TEST(TransformTests, TestTransformIfUnaryNoStencil)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -754,6 +756,8 @@ TYPED_TEST(TransformTests, TestTransformIfUnaryNoStencil)
                                  thrust::negate<T>(),
                                  is_positive());
 
+            h_input.clear();
+
             ASSERT_EQ(h_output, d_output);
         }
     }
@@ -766,7 +770,7 @@ TYPED_TEST(TransformTests, TestTransformIfUnary)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -808,6 +812,9 @@ TYPED_TEST(TransformTests, TestTransformIfUnary)
                                  thrust::negate<T>(),
                                  is_positive());
 
+            h_input.clear();
+            h_stencil.clear();
+
             ASSERT_EQ(h_output, d_output);
         }
     }
@@ -819,7 +826,7 @@ TYPED_TEST(TransformTests, TestTransformIfUnaryToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -869,7 +876,7 @@ TYPED_TEST(TransformTests, TestTransformBinary)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -927,7 +934,7 @@ TYPED_TEST(TransformTests, TestTransformBinaryToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -972,7 +979,7 @@ TYPED_TEST(TransformTests, TestTransformIfBinary)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(4))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -1060,7 +1067,7 @@ TYPED_TEST(TransformTests, TestTransformIfBinaryToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(3))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -1125,7 +1132,7 @@ TYPED_TEST(TransformTests, TestTransformUnaryCountingIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         size = thrust::min<size_t>(size, std::numeric_limits<T>::max());
 
@@ -1151,7 +1158,7 @@ TYPED_TEST(TransformTests, TestTransformBinaryCountingIterators)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         size = thrust::min<size_t>(size, std::numeric_limits<T>::max());
 

--- a/test/test_unique.cpp
+++ b/test/test_unique.cpp
@@ -157,7 +157,7 @@ TYPED_TEST(UniqueIntegralTests, TestUnique)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -234,7 +234,7 @@ TYPED_TEST(UniqueIntegralTests, TestUniqueCopy)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>(2))
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 
@@ -271,7 +271,7 @@ TYPED_TEST(UniqueIntegralTests, TestUniqueCopyToDiscardIterator)
 
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
-    for(auto size : get_sizes())
+    for(auto size : get_sizes<T>())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);
 

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -136,7 +136,7 @@ void test_event_wait(Event&& e)
 }
 
 template <typename T>
-std::vector<size_t> get_sizes(size_t count)
+std::vector<size_t> get_sizes(size_t count = 1)
 {
     std::vector<size_t> sizes = {
         0, 1, 2, 12, 63, 64, 211, 256, 344,
@@ -154,12 +154,14 @@ std::vector<size_t> get_sizes(size_t count)
                     "hipMemGetInfo: hipErrorInvalidValue")
                 };
 
-        constexpr double capacity = 0.95;
+        constexpr double capacity = 0.92;
         sizes.push_back(size_t(free * capacity / (sizeof(T) * count)));
     }
 
     return sizes;
 }
+
+bool is_large(size_t size) { return size > (1 << 20) - 123; }
 
 std::vector<seed_type> get_seeds()
 {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -130,12 +130,18 @@ void test_event_wait(Event&& e)
   ASSERT_EQ(true, e.ready());
 }
 
-std::vector<size_t> get_sizes()
+template <typename T>
+std::vector<size_t> get_sizes(size_t temp_count)
 {
     std::vector<size_t> sizes = {
         0, 1, 2, 12, 63, 64, 211, 256, 344,
         1024, 2048, 5096, 34567, (1 << 17) - 1220, 1000000, (1 << 20) - 123
     };
+    if(large_tests)
+    {
+        sizes.push_back(0);
+    }
+
     return sizes;
 }
 


### PR DESCRIPTION
# WIP: Large data tests

## What?

Prototype of unit tests operating on datasets near VRAM capacity.

## Why?

EXSWSTRHPC-54

## How?

### Design considerations

#### Add new test cases

The request was to optionally extend the test matrix with tests operating on datasets near VRAM capacity. We considered adding new tests, fo eg. beside having `TEST_CASE(SortTests, TestSortSimple)` adding `TEST_CASE(SortTests, TestSortLarge)` etc. The only difference in these tests however would be just removing the loop over pre-defined input sizes. This would result in _massive_ code duplication.

#### Optionally present "pre-defined" size

Luckily the new test matrix dimension isn't totally new, so we came up with an approach that is perhaps the least intrusive toward existing test code. By minimally changing the signature of the `get_sizes()` method, we can append a size that adapts to the test invoking it to return a size which will stress the HW near VRAM capacity.

_This direction was deemed most efficient._

#### On using MWC64X

To make tests reproducible that don't depend on the core count of the host machine, we needed finer grain control over the PRNG used for random input. We borrowed a 3-way BSD licenses generator from [SYCL-PRNG](https://github.com/Wigner-GPU-Lab/SYCL-PRNG), MWC64X ([original](http://cas.ee.ic.ac.uk/people/dt10/research/rngs-gpu-mwc64x.html)) which is an extremely fast PRNG engine with simple step and skip functions.

All STL and Thrust PRNG engines expose the `discard()` member which in theory could be used for predictable parallel sequence generation, however none of them actually implement the otherwise existing skip functions of the random engines. (They instead take the allowed shortcut of disposing of states in a for loop.) To [predictably generate the same sequence of numbers in parallel](https://github.com/ROCmSoftwarePlatform/rocThrust/blob/c3c086f2cf19371a5877111e9cdc31a8c2ced497/test/test_utils.hpp#L81-L99) using any number of parallel threads, we must be able to skip to arbitrary lengths in the sequence in constant time.

_Note: The SYCL port doesn't depend on SYCL at all, doesn't even include the header. Instead it satisfies [UniformRandomBitGenerator](https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator) and [StandardLayoutType](https://en.cppreference.com/w/cpp/named_req/StandardLayoutType) named requirements. It's 100% ISO C++._

_Note2: MWC64X isn't a hard requirement, any skippable generator can do the trick. Since I authored the SYCL port, I knew this was available and was trivial to integrate._

### Changes

- A new (`OFF` by default) CMake option was added: `LARGE_TEST` which enables the feature.
- When the feature is enabled, host side data generation became a serious bottleneck (especially with Vega20 cards). The host process generating ~30GB random short, int, long, (and their unsigned variants), float, double for all test cases for all random seeds... one single `TEST_CASE()` could easily run for 90 minutes.
  - As a result `THRUST_HOST_SYSTEM_TBB` is used throughout the tests to lower their runtime to tolerable ranges, currently unconditionally (irrespective of `LARGE_TEST` being enabled or not).
  - Change from `std::default_random_engine` to `prng::mwc64x_32`
- Changed the signature of `std::vector<size_t> get_sizes()` to `template <typename T> std::vector<size_t> get_sizes(size_t count)`
  - The method has to know the size of the type it'll be generating _and_ the number of parallel instances of input/output sequences.
  - The method has a `constexpr double capacity = 0.92;` tuning parameter which sets a target for VRAM consumption. It is intentionally under 100%, as algorithms often need temporary storage that will increase mem usage requirements anyway. A more robust approach could've been designed at the expense of increased complexity.
- Reworked the `get_random_data()` method for parallel random input generation.
- Prototyped test changes for the following tests as an example of the necessary changes in all of the tests. (Essentially one has to update all calls to `get_sizes()` and tune the `count` parameter.)
  - `test_reduce.cpp`
  - `test_transform.cpp`
  - `test_scan.cpp`
  - `test_sort.cpp`
  - `test_count.cpp`
  - `test_find.cpp`
  - `test_partition.cpp`

### Challanges

If all it took to simply update all call sites of `get_sizes()` and decreasing `count` to a point we don't get out-of-memory exceptions, the entire test suite could be updated in 2-3 days (after coming up with this design and prototype to begin with). The problem is that many tests could benefit from slight modifications to their resource usage. [Clearing unneded host-side memory](https://github.com/ROCmSoftwarePlatform/rocThrust/compare/large-tests?expand=1#diff-8c34639d24c132eaf33c5488a0f37e6eR123-R124), [rearranging the order of tasks](https://github.com/ROCmSoftwarePlatform/rocThrust/compare/large-tests?expand=1#diff-8c34639d24c132eaf33c5488a0f37e6eR599-R600), [reason about tests making sense at all on 8 billion floating-point elements](https://github.com/ROCmSoftwarePlatform/rocThrust/compare/large-tests?expand=1#diff-fb957f52c52a309716595c52a0da3ebbR248), etc.

Reductions were likely one of the few problematic tests that took a long time, "search-like" algorithms behave better in this regard. If tests use more RAM then necessary, it can happen that RAM usage exceeds double the VRAM of all cards used. (One reference set, and one device result + temporaries left behind.) Glossing over all 210 tests that use `get_sizes()` and are candidates to subjecting them to large tests requires time and care. _The tests were not written with extreme resource pressure in mind._

Large tests generally conflict with multi-GPU testing on the premise that one may require double the RAM of all VRAM, or slightly more. All of our CI machines have at least 2 GPUs and the same amount of RAM as VRAM. Even in optimal scenarios, we could not run multi-GPU large tests without upgrades to the system, even in the optimal case of ultimately having _only_ the reference and the validation dataset in memory.

## Next?

- If the design is favorable, complete porting all tests.
- If resource constraints are too high, implement some streaming mechanism to alleviate needing as much RAM.
  - Stream reference data from disk in chunks for validation and keep only device result in RAM.
  - Stream device result in chunks for validation and keep only reference in RAM.
    - This latter is perhaps the least intrusive: it requires removing the fetching of device results to host and directly invoke a new `ASSERT_EQ()`-like macros/functions that takes care of the streaming internally. Some tests at times make clever resuse of device results, but those aren't many in number.

**Please reflect on future directions and the general approach thus far.**