### PR TITLE
Fix rocThrust building failure due to hcc codes removed from hip

### DIFF
--- a/install
+++ b/install
@@ -140,7 +140,7 @@ fi
 if [[ "${build_relocatable}" == true ]]; then
     CXX=$rocm_path/bin/${compiler} ${cmake_executable} \
         -DCMAKE_INSTALL_PREFIX=${rocm_path} \
-        -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \
+        -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hip" \
         -DCMAKE_MODULE_PATH="${rocm_path}/hip/cmake" \
         -DROCPRIM_ROOT=${rocm_path}/rocprim ${build_test}\
          ../../. # or cmake-gui ../.

--- a/thrust/system/hip/detail/guarded_driver_types.h
+++ b/thrust/system/hip/detail/guarded_driver_types.h
@@ -37,7 +37,7 @@
 #    define THRUST_DEVICE_NEEDS_RESTORATION
 #  endif
 #else // GNUC pre 4.5.0
-#  if !defined(HIP_INCLUDE_HIP_HCC_DETAIL_DRIVER_TYPES_H)
+#  if !defined(HIP_INCLUDE_HIP_AMD_DETAIL_DRIVER_TYPES_H)
 #    ifdef __host__
 #      undef __host__
 #    endif
@@ -47,7 +47,7 @@
 #  endif // __DRIVER_TYPES_H__
 #endif // __GNUC__
 
-#include <hip/hcc_detail/host_defines.h>
+#include <hip/amd_detail/host_defines.h>
 
 #if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40500)
 #  ifdef THRUST_HOST_NEEDS_RESTORATION

--- a/thrust/system/hip/detail/guarded_hip_runtime_api.h
+++ b/thrust/system/hip/detail/guarded_hip_runtime_api.h
@@ -23,7 +23,7 @@
 // such as __host__ and __device__, which may already be defined by thrust
 // and to undefine them before entering hip/hip_runtime_api.h (which will redefine them)
 
-#if !defined(HIP_INCLUDE_HIP_HCC_DETAIL_HOST_DEFINES_H)
+#if !defined(HIP_INCLUDE_HIP_AMD_DETAIL_HOST_DEFINES_H)
 
 #ifdef __host__
 #undef __host__


### PR DESCRIPTION
Change  HIP_INCLUDE_HIP_HCC_DETAIL_DRIVER_TYPES_H into
HIP_INCLUDE_HIP_AMD_DETAIL_DRIVER_TYPES_H

Change HIP_INCLUDE_HIP_HCC_DETAIL_HOST_DEFINES_H into 
HIP_INCLUDE_HIP_AMD_DETAIL_HOST_DEFINES_H