### PR TITLE
Temporary workaround for size zero inputs when grid/block dim minimum size is 1

### DIFF
--- a/test/test_partition.cpp
+++ b/test/test_partition.cpp
@@ -354,6 +354,17 @@ TYPED_TEST(PartitionIntegerTests, TestPartition)
             typename thrust::device_vector<T>::iterator d_iter
                 = thrust::partition(d_data.begin(), d_data.end(), is_even<T>());
 
+            size_t h_iter_size1 = static_cast<size_t>(thrust::distance(h_data.begin(), h_iter));
+            size_t d_iter_size1 = static_cast<size_t>(thrust::distance(d_data.begin(), d_iter));
+            size_t h_iter_size2 = static_cast<size_t>(thrust::distance(h_iter, h_data.end()));
+            size_t d_iter_size2 = static_cast<size_t>(thrust::distance(d_iter, d_data.end()));
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (h_iter_size1 == 0 || d_iter_size1 == 0 || h_iter_size2 == 0 || d_iter_size2 == 0)
+            {
+                continue;
+            }
+
             thrust::sort(h_data.begin(), h_iter);
             thrust::sort(h_iter, h_data.end());
             thrust::sort(d_data.begin(), d_iter);
@@ -395,6 +406,17 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionStencil)
             typename thrust::device_vector<T>::iterator d_iter
                 = thrust::partition(d_data.begin(), d_data.end(), d_stencil.begin(), is_even<T>());
 
+            size_t h_iter_size1 = static_cast<size_t>(thrust::distance(h_data.begin(), h_iter));
+            size_t d_iter_size1 = static_cast<size_t>(thrust::distance(d_data.begin(), d_iter));
+            size_t h_iter_size2 = static_cast<size_t>(thrust::distance(h_iter, h_data.end()));
+            size_t d_iter_size2 = static_cast<size_t>(thrust::distance(d_iter, d_data.end()));
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (h_iter_size1 == 0 || d_iter_size1 == 0 || h_iter_size2 == 0 || d_iter_size2 == 0)
+            {
+                continue;
+            }
+
             thrust::sort(h_data.begin(), h_iter);
             thrust::sort(h_iter, h_data.end());
             thrust::sort(d_data.begin(), d_iter);
@@ -427,6 +449,9 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopy)
 
             size_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
             size_t n_false = size - n_true;
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
 
             // setup output ranges
             thrust::host_vector<T>   h_true_results(n_true, 0);
@@ -495,6 +520,9 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopyStencil)
 
             size_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
             size_t n_false = size - n_true;
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
 
             // setup output ranges
             thrust::host_vector<T>   h_true_results(n_true, 0);
@@ -566,6 +594,9 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopyStencil)
             size_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
             size_t n_false = size - n_true;
 
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
+
             // setup output ranges
             thrust::host_vector<T>   h_true_results(n_true, 0);
             thrust::host_vector<T>   h_false_results(n_false, 0);
@@ -628,6 +659,9 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopyToDiscardIterator)
 
             size_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
             size_t n_false = size - n_true;
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
 
             // mask both ranges
             thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1
@@ -743,6 +777,9 @@ TYPED_TEST(PartitionIntegerTests, TestPartitionCopyStencilToDiscardIterator)
 
             size_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
             size_t n_false = size - n_true;
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
 
             // mask both ranges
             thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1
@@ -924,6 +961,9 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopy)
             size_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
             size_t n_false = size - n_true;
 
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
+
             // setup output ranges
             thrust::host_vector<T>   h_true_results(n_true, 0);
             thrust::host_vector<T>   h_false_results(n_false, 0);
@@ -980,6 +1020,9 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopyToDiscardIterator)
 
             size_t n_true  = thrust::count_if(h_data.begin(), h_data.end(), is_even<T>());
             size_t n_false = size - n_true;
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
 
             // mask both ranges
             thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1
@@ -1094,6 +1137,9 @@ TYPED_TEST(PartitionIntegerTests, TestStablePartitionCopyStencilToDiscardIterato
 
             size_t n_true  = thrust::count_if(h_stencil.begin(), h_stencil.end(), is_even<T>());
             size_t n_false = size - n_true;
+
+            // TODO: Temporary workaround for size 0 inputs with grid/block min dim > 1
+            if (n_true == 0 || n_false == 0) continue;
 
             // mask both ranges
             thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -133,7 +133,7 @@ void test_event_wait(Event&& e)
 std::vector<size_t> get_sizes()
 {
     std::vector<size_t> sizes = {
-        0, 1, 2, 12, 63, 64, 211, 256, 344,
+        1, 2, 12, 63, 64, 211, 256, 344,
         1024, 2048, 5096, 34567, (1 << 17) - 1220, 1000000, (1 << 20) - 123
     };
     return sizes;


### PR DESCRIPTION
As per internal discussion, HIP runtime is being fixed to not allow grid/block dims of size zero.  Until we can fix rocPRIM/rocThrust to match this new behaviour, temporarily disabling unit test cases that have size zero inputs.