### PR TITLE
Find rocm-cmake before specifying targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,6 @@ set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific ma
 # Verify that hcc or hipcc compiler is used on ROCM platform
 include(cmake/VerifyCompiler.cmake)
 
-# Get dependencies
-include(cmake/Dependencies.cmake)
-
 # Build options
 # Disable -Werror
 option(DISABLE_WERROR "Disable building with Werror" ON)
@@ -107,6 +104,9 @@ if(DISABLE_WERROR)
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 endif()
+
+# Get dependencies
+include(cmake/Dependencies.cmake)
 
 # Setup VERSION
 rocm_setup_version(VERSION "2.10.9")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,15 @@ endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
 
-# Get dependencies
-include(cmake/Dependencies.cmake)
+# rocm-cmake contains common cmake code for rocm projects to help
+# setup and install
+find_package( ROCM CONFIG )
+include( ROCMSetupVersion )
+include( ROCMCreatePackage )
+include( ROCMInstallTargets )
+include( ROCMPackageConfigHelpers )
+include( ROCMInstallSymlinks )
+include( ROCMCheckTargetIds OPTIONAL )
 
 # Detect compiler support for target ID
 # This section is deprecated. Please use rocm_check_target_ids for future use.
@@ -62,6 +69,9 @@ set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific ma
 
 # Verify that hcc or hipcc compiler is used on ROCM platform
 include(cmake/VerifyCompiler.cmake)
+
+# Get dependencies
+include(cmake/Dependencies.cmake)
 
 # Build options
 # Disable -Werror

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -60,39 +60,3 @@ if(BUILD_TEST)
   )
   find_package(GTest REQUIRED)
 endif()
-
-# Find or download/install rocm-cmake project
-find_package(ROCM QUIET CONFIG PATHS /opt/rocm)
-if(NOT ROCM_FOUND)
-  set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
-  file(
-    DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-    ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-    STATUS rocm_cmake_download_status LOG rocm_cmake_download_log
-  )
-  list(GET rocm_cmake_download_status 0 rocm_cmake_download_error_code)
-  if(rocm_cmake_download_error_code)
-    message(FATAL_ERROR "Error: downloading "
-      "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip failed "
-      "error_code: ${rocm_cmake_download_error_code} "
-      "log: ${rocm_cmake_download_log} "
-    )
-  endif()
-
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    RESULT_VARIABLE rocm_cmake_unpack_error_code
-  )
-  if(rocm_cmake_unpack_error_code)
-    message(FATAL_ERROR "Error: unpacking  ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
-  endif()
-  find_package(ROCM REQUIRED CONFIG PATHS ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag})
-endif()
-
-include(ROCMSetupVersion)
-include(ROCMCreatePackage)
-include(ROCMInstallTargets)
-include(ROCMPackageConfigHelpers)
-include(ROCMInstallSymlinks)
-include(ROCMCheckTargetIds OPTIONAL)


### PR DESCRIPTION
Dependencies.cmake found both rocprim and rocm-cmake. rocm-cmake needs to be found before specifying targets, and rocprim after. So I have split it up. I also removed the manual download of rocm-cmake as it looks like other libraries do not attempt a download either