### PR TITLE
Enable ccache on CI

### DIFF
--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -15,6 +15,7 @@ def runCI =
 
     def prj = new rocProject('rocThrust', 'precheckin')
 
+    prj.defaults.ccache = true
     prj.timeout.compile = 420
 
     // Define test architectures, optional rocm version argument is available

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -10,6 +10,7 @@ def runCI =
     
     def prj = new rocProject('rocThrust', 'Static Library PreCheckin')
 
+    prj.defaults.ccache = true
     prj.timeout.compile = 420
 
     def nodes = new dockerNodes(nodeDetails, jobName, prj)


### PR DESCRIPTION
This PR makes use of ccache the default setting for rocThrust builds on the CI. It can be disabled for PRs using the label `ci:no-ccache`.