### PR TITLE
Updating thrust scan documentation to warn about mixing input/output types

### DIFF
--- a/thrust/scan.h
+++ b/thrust/scan.h
@@ -40,20 +40,24 @@ namespace thrust
 
 /*! \p inclusive_scan computes an inclusive prefix sum operation. The
  *  term 'inclusive' means that each result includes the corresponding
- *  input operand in the partial sum. More precisely, <tt>*first</tt> is 
- *  assigned to <tt>*result</tt> and the sum of <tt>*first</tt> and 
- *  <tt>*(first + 1)</tt> is assigned to <tt>*(result + 1)</tt>, and so on. 
- *  This version of \p inclusive_scan assumes plus as the associative operator.  
- *  When the input and output sequences are the same, the scan is performed 
+ *  input operand in the partial sum. More precisely, <tt>*first</tt> is
+ *  assigned to <tt>*result</tt> and the sum of <tt>*first</tt> and
+ *  <tt>*(first + 1)</tt> is assigned to <tt>*(result + 1)</tt>, and so on.
+ *  This version of \p inclusive_scan assumes plus as the associative operator.
+ *  When the input and output sequences are the same, the scan is performed
  *  in-place.
- 
+
  *  \p inclusive_scan is similar to \c std::partial_sum in the STL.  The primary
  *  difference between the two functions is that \c std::partial_sum guarantees
- *  a serial summation order, while \p inclusive_scan requires associativity of 
+ *  a serial summation order, while \p inclusive_scan requires associativity of
  *  the binary operation to parallelize the prefix sum.
  *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by casting the input iterators to match the appropriate output type
+ *  via transform_iterator().
+ *
  *  The algorithm's execution is parallelized as determined by \p exec.
- *    
+ *
  *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
@@ -79,7 +83,7 @@ namespace thrust
  *  #include <thrust/scan.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int data[6] = {1, 0, 2, 2, 1, 3};
  *
  *  thrust::inclusive_scan(thrust::host, data, data + 6, data); // in-place scan
@@ -102,18 +106,22 @@ __host__ __device__
 
 /*! \p inclusive_scan computes an inclusive prefix sum operation. The
  *  term 'inclusive' means that each result includes the corresponding
- *  input operand in the partial sum. More precisely, <tt>*first</tt> is 
- *  assigned to <tt>*result</tt> and the sum of <tt>*first</tt> and 
- *  <tt>*(first + 1)</tt> is assigned to <tt>*(result + 1)</tt>, and so on. 
- *  This version of \p inclusive_scan assumes plus as the associative operator.  
- *  When the input and output sequences are the same, the scan is performed 
+ *  input operand in the partial sum. More precisely, <tt>*first</tt> is
+ *  assigned to <tt>*result</tt> and the sum of <tt>*first</tt> and
+ *  <tt>*(first + 1)</tt> is assigned to <tt>*(result + 1)</tt>, and so on.
+ *  This version of \p inclusive_scan assumes plus as the associative operator.
+ *  When the input and output sequences are the same, the scan is performed
  *  in-place.
- 
+ *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by casting the input iterators to match the appropriate output type
+ *  via transform_iterator().
+ *
  *  \p inclusive_scan is similar to \c std::partial_sum in the STL.  The primary
  *  difference between the two functions is that \c std::partial_sum guarantees
- *  a serial summation order, while \p inclusive_scan requires associativity of 
+ *  a serial summation order, while \p inclusive_scan requires associativity of
  *  the binary operation to parallelize the prefix sum.
- *    
+ *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
  *  \param result The beginning of the output sequence.
@@ -134,7 +142,7 @@ __host__ __device__
  *
  *  \code
  *  #include <thrust/scan.h>
- *  
+ *
  *  int data[6] = {1, 0, 2, 2, 1, 3};
  *
  *  thrust::inclusive_scan(data, data + 6, data); // in-place scan
@@ -154,13 +162,17 @@ template<typename InputIterator,
 
 /*! \p inclusive_scan computes an inclusive prefix sum operation. The
  *  term 'inclusive' means that each result includes the corresponding
- *  input operand in the partial sum.  When the input and output sequences 
+ *  input operand in the partial sum.  When the input and output sequences
  *  are the same, the scan is performed in-place.
- *    
+ *
  *  \p inclusive_scan is similar to \c std::partial_sum in the STL.  The primary
  *  difference between the two functions is that \c std::partial_sum guarantees
- *  a serial summation order, while \p inclusive_scan requires associativity of 
+ *  a serial summation order, while \p inclusive_scan requires associativity of
  *  the binary operation to parallelize the prefix sum.
+ *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by casting the input iterators to match the appropriate output type
+ *  via transform_iterator().
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -190,7 +202,7 @@ template<typename InputIterator,
  *
  *  \code
  *  int data[10] = {-5, 0, 2, -3, 2, 4, 0, -1, 2, 8};
- * 
+ *
  *  thrust::maximum<int> binary_op;
  *
  *  thrust::inclusive_scan(thrust::host, data, data + 10, data, binary_op); // in-place scan
@@ -214,13 +226,17 @@ __host__ __device__
 
 /*! \p inclusive_scan computes an inclusive prefix sum operation. The
  *  term 'inclusive' means that each result includes the corresponding
- *  input operand in the partial sum.  When the input and output sequences 
+ *  input operand in the partial sum.  When the input and output sequences
  *  are the same, the scan is performed in-place.
- *    
+ *
  *  \p inclusive_scan is similar to \c std::partial_sum in the STL.  The primary
  *  difference between the two functions is that \c std::partial_sum guarantees
- *  a serial summation order, while \p inclusive_scan requires associativity of 
+ *  a serial summation order, while \p inclusive_scan requires associativity of
  *  the binary operation to parallelize the prefix sum.
+ *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by casting the input iterators to match the appropriate output type
+ *  via transform_iterator().
  *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
@@ -245,7 +261,7 @@ __host__ __device__
  *
  *  \code
  *  int data[10] = {-5, 0, 2, -3, 2, 4, 0, -1, 2, 8};
- * 
+ *
  *  thrust::maximum<int> binary_op;
  *
  *  thrust::inclusive_scan(data, data + 10, data, binary_op); // in-place scan
@@ -265,16 +281,19 @@ template<typename InputIterator,
 
 
 /*! \p exclusive_scan computes an exclusive prefix sum operation. The
- *  term 'exclusive' means that each result does not include the 
+ *  term 'exclusive' means that each result does not include the
  *  corresponding input operand in the partial sum.  More precisely,
- *  <tt>0</tt> is assigned to <tt>*result</tt> and the sum of 
+ *  <tt>0</tt> is assigned to <tt>*result</tt> and the sum of
  *  <tt>0</tt> and <tt>*first</tt> is assigned to <tt>*(result + 1)</tt>,
- *  and so on. This version of \p exclusive_scan assumes plus as the 
- *  associative operator and \c 0 as the initial value.  When the input and 
+ *  and so on. This version of \p exclusive_scan assumes plus as the
+ *  associative operator and \c 0 as the initial value.  When the input and
  *  output sequences are the same, the scan is performed in-place.
  *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *
  *  The algorithm's execution is parallelized as determined by \p exec.
- *    
+ *
  *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
@@ -300,7 +319,7 @@ template<typename InputIterator,
  *  #include <thrust/scan.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int data[6] = {1, 0, 2, 2, 1, 3};
  *
  *  thrust::exclusive_scan(thrust::host, data, data + 6, data); // in-place scan
@@ -321,14 +340,17 @@ __host__ __device__
 
 
 /*! \p exclusive_scan computes an exclusive prefix sum operation. The
- *  term 'exclusive' means that each result does not include the 
+ *  term 'exclusive' means that each result does not include the
  *  corresponding input operand in the partial sum.  More precisely,
- *  <tt>0</tt> is assigned to <tt>*result</tt> and the sum of 
+ *  <tt>0</tt> is assigned to <tt>*result</tt> and the sum of
  *  <tt>0</tt> and <tt>*first</tt> is assigned to <tt>*(result + 1)</tt>,
- *  and so on. This version of \p exclusive_scan assumes plus as the 
- *  associative operator and \c 0 as the initial value.  When the input and 
+ *  and so on. This version of \p exclusive_scan assumes plus as the
+ *  associative operator and \c 0 as the initial value.  When the input and
  *  output sequences are the same, the scan is performed in-place.
- *    
+ *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
  *  \param result The beginning of the output sequence.
@@ -349,7 +371,7 @@ __host__ __device__
  *
  *  \code
  *  #include <thrust/scan.h>
- *  
+ *
  *  int data[6] = {1, 0, 2, 2, 1, 3};
  *
  *  thrust::exclusive_scan(data, data + 6, data); // in-place scan
@@ -367,13 +389,16 @@ template<typename InputIterator,
 
 
 /*! \p exclusive_scan computes an exclusive prefix sum operation. The
- *  term 'exclusive' means that each result does not include the 
+ *  term 'exclusive' means that each result does not include the
  *  corresponding input operand in the partial sum.  More precisely,
- *  \p init is assigned to <tt>*result</tt> and the sum of \p init and 
- *  <tt>*first</tt> is assigned to <tt>*(result + 1)</tt>, and so on. 
- *  This version of \p exclusive_scan assumes plus as the associative 
- *  operator but requires an initial value \p init.  When the input and 
+ *  \p init is assigned to <tt>*result</tt> and the sum of \p init and
+ *  <tt>*first</tt> is assigned to <tt>*(result + 1)</tt>, and so on.
+ *  This version of \p exclusive_scan assumes plus as the associative
+ *  operator but requires an initial value \p init.  When the input and
  *  output sequences are the same, the scan is performed in-place.
+ *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -401,7 +426,7 @@ template<typename InputIterator,
  *  \code
  *  #include <thrust/scan.h>
  *  #include <thrust/execution_policy.h>
- *  
+ *
  *  int data[6] = {1, 0, 2, 2, 1, 3};
  *
  *  thrust::exclusive_scan(thrust::host, data, data + 6, data, 4); // in-place scan
@@ -424,13 +449,16 @@ __host__ __device__
 
 
 /*! \p exclusive_scan computes an exclusive prefix sum operation. The
- *  term 'exclusive' means that each result does not include the 
+ *  term 'exclusive' means that each result does not include the
  *  corresponding input operand in the partial sum.  More precisely,
- *  \p init is assigned to <tt>*result</tt> and the sum of \p init and 
- *  <tt>*first</tt> is assigned to <tt>*(result + 1)</tt>, and so on. 
- *  This version of \p exclusive_scan assumes plus as the associative 
- *  operator but requires an initial value \p init.  When the input and 
+ *  \p init is assigned to <tt>*result</tt> and the sum of \p init and
+ *  <tt>*first</tt> is assigned to <tt>*(result + 1)</tt>, and so on.
+ *  This version of \p exclusive_scan assumes plus as the associative
+ *  operator but requires an initial value \p init.  When the input and
  *  output sequences are the same, the scan is performed in-place.
+ *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
  *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
@@ -452,7 +480,7 @@ __host__ __device__
  *
  *  \code
  *  #include <thrust/scan.h>
- *  
+ *
  *  int data[6] = {1, 0, 2, 2, 1, 3};
  *
  *  thrust::exclusive_scan(data, data + 6, data, 4); // in-place scan
@@ -472,16 +500,19 @@ template<typename InputIterator,
 
 
 /*! \p exclusive_scan computes an exclusive prefix sum operation. The
- *  term 'exclusive' means that each result does not include the 
+ *  term 'exclusive' means that each result does not include the
  *  corresponding input operand in the partial sum.  More precisely,
  *  \p init is assigned to <tt>\*result</tt> and the value
  *  <tt>binary_op(init, \*first)</tt> is assigned to <tt>\*(result + 1)</tt>,
- *  and so on. This version of the function requires both an associative 
+ *  and so on. This version of the function requires both an associative
  *  operator and an initial value \p init.  When the input and output
  *  sequences are the same, the scan is performed in-place.
  *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *
  *  The algorithm's execution is parallelized as determined by \p exec.
- *    
+ *
  *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
@@ -513,16 +544,16 @@ template<typename InputIterator,
  *  #include <thrust/functional.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int data[10] = {-5, 0, 2, -3, 2, 4, 0, -1, 2, 8};
- * 
+ *
  *  thrust::maximum<int> binary_op;
  *
  *  thrust::exclusive_scan(thrust::host, data, data + 10, data, 1, binary_op); // in-place scan
  *
  *  // data is now {1, 1, 1, 2, 2, 2, 4, 4, 4, 4 }
  *  \endcode
- *  
+ *
  *  \see http://www.sgi.com/tech/stl/partial_sum.html
  */
 template<typename DerivedPolicy,
@@ -540,14 +571,17 @@ __host__ __device__
 
 
 /*! \p exclusive_scan computes an exclusive prefix sum operation. The
- *  term 'exclusive' means that each result does not include the 
+ *  term 'exclusive' means that each result does not include the
  *  corresponding input operand in the partial sum.  More precisely,
  *  \p init is assigned to <tt>\*result</tt> and the value
  *  <tt>binary_op(init, \*first)</tt> is assigned to <tt>\*(result + 1)</tt>,
- *  and so on. This version of the function requires both an associative 
+ *  and so on. This version of the function requires both an associative
  *  operator and an initial value \p init.  When the input and output
  *  sequences are the same, the scan is performed in-place.
- *    
+ *
+ *  Note that currently mixing scan input and output types can cause undefined behaviour.
+ *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
  *  \param result The beginning of the output sequence.
@@ -574,16 +608,16 @@ __host__ __device__
  *  \code
  *  #include <thrust/scan.h>
  *  #include <thrust/functional.h>
- *  
+ *
  *  int data[10] = {-5, 0, 2, -3, 2, 4, 0, -1, 2, 8};
- * 
+ *
  *  thrust::maximum<int> binary_op;
  *
  *  thrust::exclusive_scan(data, data + 10, data, 1, binary_op); // in-place scan
  *
  *  // data is now {1, 1, 1, 2, 2, 2, 4, 4, 4, 4 }
  *  \endcode
- *  
+ *
  *  \see http://www.sgi.com/tech/stl/partial_sum.html
  */
 template<typename InputIterator,
@@ -603,8 +637,8 @@ template<typename InputIterator,
  */
 
 
-/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix 
- *  sum operation. The term 'inclusive' means that each result includes 
+/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix
+ *  sum operation. The term 'inclusive' means that each result includes
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
  *  words, within each segment a separate inclusive scan operation is computed.
@@ -634,7 +668,7 @@ template<typename InputIterator,
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *
  *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
@@ -647,7 +681,7 @@ template<typename InputIterator,
  *  #include <thrust/scan.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int data[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *
@@ -670,10 +704,10 @@ __host__ __device__
                                        InputIterator1 last1,
                                        InputIterator2 first2,
                                        OutputIterator result);
- 
 
-/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix 
- *  sum operation. The term 'inclusive' means that each result includes 
+
+/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix
+ *  sum operation. The term 'inclusive' means that each result includes
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
  *  words, within each segment a separate inclusive scan operation is computed.
@@ -699,7 +733,7 @@ __host__ __device__
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *
  *  \pre \p first1 may equal \p result but the range <tt>[first1, last1)</tt> and the range <tt>[result, result + (last1 - first1))</tt> shall not overlap otherwise.
@@ -709,7 +743,7 @@ __host__ __device__
  *
  *  \code
  *  #include <thrust/scan.h>
- *  
+ *
  *  int data[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *
@@ -731,24 +765,24 @@ template<typename InputIterator1,
                                        OutputIterator result);
 
 
-/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix 
- *  sum operation. The term 'inclusive' means that each result includes 
+/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix
+ *  sum operation. The term 'inclusive' means that each result includes
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
  *  words, within each segment a separate inclusive scan operation is computed.
  *  Refer to the code sample below for example usage.
  *
- *  This version of \p inclusive_scan_by_key uses the binary predicate 
+ *  This version of \p inclusive_scan_by_key uses the binary predicate
  *  \c pred to compare adjacent keys.  Specifically, consecutive iterators
  *  <tt>i</tt> and <tt>i+1</tt> in the range <tt>[first1, last1)</tt>
- *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to 
+ *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to
  *  different segments otherwise.
  *
  *  This version of \p inclusive_scan_by_key assumes \c plus as the associative
  *  operator used to perform the prefix sum. When the input and output sequences
  *  are the same, the scan is performed in-place.
  *
- *  The algorithm's execution is parallelized as determined by \p exec. 
+ *  The algorithm's execution is parallelized as determined by \p exec.
  *
  *  \param exec The execution policy to use for parallelization.
  *  \param first1 The beginning of the key sequence.
@@ -763,7 +797,7 @@ template<typename InputIterator1,
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *  \tparam BinaryPredicate is a model of <a href="http://www.sgi.com/tech/stl/BinaryPredicate.html">Binary Predicate</a>.
  *
@@ -778,7 +812,7 @@ template<typename InputIterator1,
  *  #include <thrust/functional.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int data[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *
@@ -807,17 +841,17 @@ __host__ __device__
                                        BinaryPredicate binary_pred);
 
 
-/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix 
- *  sum operation. The term 'inclusive' means that each result includes 
+/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix
+ *  sum operation. The term 'inclusive' means that each result includes
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
  *  words, within each segment a separate inclusive scan operation is computed.
  *  Refer to the code sample below for example usage.
  *
- *  This version of \p inclusive_scan_by_key uses the binary predicate 
+ *  This version of \p inclusive_scan_by_key uses the binary predicate
  *  \c pred to compare adjacent keys.  Specifically, consecutive iterators
  *  <tt>i</tt> and <tt>i+1</tt> in the range <tt>[first1, last1)</tt>
- *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to 
+ *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to
  *  different segments otherwise.
  *
  *  This version of \p inclusive_scan_by_key assumes \c plus as the associative
@@ -835,7 +869,7 @@ __host__ __device__
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *  \tparam BinaryPredicate is a model of <a href="http://www.sgi.com/tech/stl/BinaryPredicate.html">Binary Predicate</a>.
  *
@@ -847,7 +881,7 @@ __host__ __device__
  *  \code
  *  #include <thrust/scan.h>
  *  #include <thrust/functional.h>
- *  
+ *
  *  int data[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *
@@ -873,20 +907,20 @@ template<typename InputIterator1,
                                        BinaryPredicate binary_pred);
 
 
-/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix 
- *  sum operation. The term 'inclusive' means that each result includes 
+/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix
+ *  sum operation. The term 'inclusive' means that each result includes
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
  *  words, within each segment a separate inclusive scan operation is computed.
  *  Refer to the code sample below for example usage.
  *
- *  This version of \p inclusive_scan_by_key uses the binary predicate 
+ *  This version of \p inclusive_scan_by_key uses the binary predicate
  *  \c pred to compare adjacent keys.  Specifically, consecutive iterators
  *  <tt>i</tt> and <tt>i+1</tt> in the range <tt>[first1, last1)</tt>
- *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to 
+ *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to
  *  different segments otherwise.
  *
- *  This version of \p inclusive_scan_by_key uses the associative operator 
+ *  This version of \p inclusive_scan_by_key uses the associative operator
  *  \c binary_op to perform the prefix sum. When the input and output sequences
  *  are the same, the scan is performed in-place.
  *
@@ -906,7 +940,7 @@ template<typename InputIterator1,
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *  \tparam BinaryPredicate is a model of <a href="http://www.sgi.com/tech/stl/BinaryPredicate.html">Binary Predicate</a>.
  *  \tparam AssociativeOperator is a model of <a href="http://www.sgi.com/tech/stl/BinaryFunction.html">Binary Function</a>
@@ -924,7 +958,7 @@ template<typename InputIterator1,
  *  #include <thrust/functional.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int data[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *
@@ -956,20 +990,20 @@ __host__ __device__
                                        AssociativeOperator binary_op);
 
 
-/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix 
- *  sum operation. The term 'inclusive' means that each result includes 
+/*! \p inclusive_scan_by_key computes an inclusive key-value or 'segmented' prefix
+ *  sum operation. The term 'inclusive' means that each result includes
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
  *  words, within each segment a separate inclusive scan operation is computed.
  *  Refer to the code sample below for example usage.
  *
- *  This version of \p inclusive_scan_by_key uses the binary predicate 
+ *  This version of \p inclusive_scan_by_key uses the binary predicate
  *  \c pred to compare adjacent keys.  Specifically, consecutive iterators
  *  <tt>i</tt> and <tt>i+1</tt> in the range <tt>[first1, last1)</tt>
- *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to 
+ *  belong to the same segment if <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to
  *  different segments otherwise.
  *
- *  This version of \p inclusive_scan_by_key uses the associative operator 
+ *  This version of \p inclusive_scan_by_key uses the associative operator
  *  \c binary_op to perform the prefix sum. When the input and output sequences
  *  are the same, the scan is performed in-place.
  *
@@ -985,7 +1019,7 @@ __host__ __device__
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *  \tparam BinaryPredicate is a model of <a href="http://www.sgi.com/tech/stl/BinaryPredicate.html">Binary Predicate</a>.
  *  \tparam AssociativeOperator is a model of <a href="http://www.sgi.com/tech/stl/BinaryFunction.html">Binary Function</a>
@@ -1000,7 +1034,7 @@ __host__ __device__
  *  \code
  *  #include <thrust/scan.h>
  *  #include <thrust/functional.h>
- *  
+ *
  *  int data[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *
@@ -1029,7 +1063,7 @@ template<typename InputIterator1,
                                        AssociativeOperator binary_op);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive segmented prefix 
+/*! \p exclusive_scan_by_key computes an exclusive segmented prefix
  *
  *  This version of \p exclusive_scan_by_key uses the value \c 0 to
  *  initialize the exclusive scan operation.
@@ -1037,11 +1071,11 @@ template<typename InputIterator1,
  *  This version of \p exclusive_scan_by_key assumes \c plus as the associative
  *  operator used to perform the prefix sum. When the input and output sequences
  *  are the same, the scan is performed in-place.
- * 
+ *
  *  This version of \p exclusive_scan_by_key assumes \c equal_to as the binary
  *  predicate used to compare adjacent keys.  Specifically, consecutive iterators
  *  <tt>i</tt> and <tt>i+1</tt> in the range <tt>[first1, last1</tt>
- *  belong to the same segment if <tt>*i == *(i+1)</tt>, and belong to 
+ *  belong to the same segment if <tt>*i == *(i+1)</tt>, and belong to
  *  different segments otherwise.
  *
  *  Refer to the most general form of \p exclusive_scan_by_key for additional details.
@@ -1064,7 +1098,7 @@ template<typename InputIterator1,
  *  #include <thrust/scan.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1088,7 +1122,7 @@ __host__ __device__
                                        OutputIterator result);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive segmented prefix 
+/*! \p exclusive_scan_by_key computes an exclusive segmented prefix
  *
  *  This version of \p exclusive_scan_by_key uses the value \c 0 to
  *  initialize the exclusive scan operation.
@@ -1096,11 +1130,11 @@ __host__ __device__
  *  This version of \p exclusive_scan_by_key assumes \c plus as the associative
  *  operator used to perform the prefix sum. When the input and output sequences
  *  are the same, the scan is performed in-place.
- * 
+ *
  *  This version of \p exclusive_scan_by_key assumes \c equal_to as the binary
  *  predicate used to compare adjacent keys.  Specifically, consecutive iterators
  *  <tt>i</tt> and <tt>i+1</tt> in the range <tt>[first1, last1</tt>
- *  belong to the same segment if <tt>*i == *(i+1)</tt>, and belong to 
+ *  belong to the same segment if <tt>*i == *(i+1)</tt>, and belong to
  *  different segments otherwise.
  *
  *  Refer to the most general form of \p exclusive_scan_by_key for additional details.
@@ -1117,7 +1151,7 @@ __host__ __device__
  *
  *  \code
  *  #include <thrust/scan.h>
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1138,7 +1172,7 @@ template<typename InputIterator1,
                                        OutputIterator result);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix 
+/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix
  *  sum operation. The term 'exclusive' means that each result does not include
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
@@ -1169,7 +1203,7 @@ template<typename InputIterator1,
  *  #include <thrust/functional.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1198,7 +1232,7 @@ __host__ __device__
                                        T init);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix 
+/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix
  *  sum operation. The term 'exclusive' means that each result does not include
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
@@ -1223,7 +1257,7 @@ __host__ __device__
  *  \code
  *  #include <thrust/scan.h>
  *  #include <thrust/functional.h>
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1249,7 +1283,7 @@ template<typename InputIterator1,
                                        T init);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix 
+/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix
  *  sum operation. The term 'exclusive' means that each result does not include
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
@@ -1286,7 +1320,7 @@ template<typename InputIterator1,
  *  #include <thrust/functional.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1319,7 +1353,7 @@ __host__ __device__
                                        BinaryPredicate binary_pred);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix 
+/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix
  *  sum operation. The term 'exclusive' means that each result does not include
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
@@ -1350,7 +1384,7 @@ __host__ __device__
  *  \code
  *  #include <thrust/scan.h>
  *  #include <thrust/functional.h>
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1380,7 +1414,7 @@ template<typename InputIterator1,
                                        BinaryPredicate binary_pred);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix 
+/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix
  *  sum operation. The term 'exclusive' means that each result does not include
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
@@ -1392,10 +1426,10 @@ template<typename InputIterator1,
  *
  *  This version of \p exclusive_scan_by_key uses the binary predicate \c binary_pred
  *  to compare adjacent keys.  Specifically, consecutive iterators <tt>i</tt> and
- *  <tt>i+1</tt> in the range <tt>[first1, last1)</tt> belong to the same segment if 
+ *  <tt>i+1</tt> in the range <tt>[first1, last1)</tt> belong to the same segment if
  *  <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to different segments otherwise.
  *
- *  This version of \p exclusive_scan_by_key uses the associative operator 
+ *  This version of \p exclusive_scan_by_key uses the associative operator
  *  \c binary_op to perform the prefix sum. When the input and output sequences
  *  are the same, the scan is performed in-place.
  *
@@ -1416,7 +1450,7 @@ template<typename InputIterator1,
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *  \tparam T is convertible to \c OutputIterator's \c value_type.
  *  \tparam BinaryPredicate is a model of <a href="http://www.sgi.com/tech/stl/BinaryPredicate.html">Binary Predicate</a>.
@@ -1434,7 +1468,7 @@ template<typename InputIterator1,
  *  #include <thrust/functional.h>
  *  #include <thrust/execution_policy.h>
  *  ...
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1470,7 +1504,7 @@ __host__ __device__
                                        AssociativeOperator binary_op);
 
 
-/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix 
+/*! \p exclusive_scan_by_key computes an exclusive key-value or 'segmented' prefix
  *  sum operation. The term 'exclusive' means that each result does not include
  *  the corresponding input operand in the partial sum. The term 'segmented'
  *  means that the partial sums are broken into distinct segments.  In other
@@ -1482,10 +1516,10 @@ __host__ __device__
  *
  *  This version of \p exclusive_scan_by_key uses the binary predicate \c binary_pred
  *  to compare adjacent keys.  Specifically, consecutive iterators <tt>i</tt> and
- *  <tt>i+1</tt> in the range <tt>[first1, last1)</tt> belong to the same segment if 
+ *  <tt>i+1</tt> in the range <tt>[first1, last1)</tt> belong to the same segment if
  *  <tt>binary_pred(*i, *(i+1))</tt> is true, and belong to different segments otherwise.
  *
- *  This version of \p exclusive_scan_by_key uses the associative operator 
+ *  This version of \p exclusive_scan_by_key uses the associative operator
  *  \c binary_op to perform the prefix sum. When the input and output sequences
  *  are the same, the scan is performed in-place.
  *
@@ -1502,7 +1536,7 @@ __host__ __device__
  *  \tparam InputIterator2 is a model of <a href="http://www.sgi.com/tech/stl/InputIterator.html">Input Iterator</a>
  *                         and \c InputIterator2's \c value_type is convertible to \c OutputIterator's \c value_type.
  *  \tparam OutputIterator is a model of <a href="http://www.sgi.com/tech/stl/OutputIterator.html">Output Iterator</a>,
- *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then 
+ *                         and if \c x and \c y are objects of \c OutputIterator's \c value_type, then
  *                         <tt>binary_op(x,y)</tt> is defined.
  *  \tparam T is convertible to \c OutputIterator's \c value_type.
  *  \tparam BinaryPredicate is a model of <a href="http://www.sgi.com/tech/stl/BinaryPredicate.html">Binary Predicate</a>.
@@ -1517,7 +1551,7 @@ __host__ __device__
  *  \code
  *  #include <thrust/scan.h>
  *  #include <thrust/functional.h>
- *  
+ *
  *  int keys[10] = {0, 0, 0, 1, 1, 2, 3, 3, 3, 3};
  *  int vals[10] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
  *
@@ -1557,7 +1591,7 @@ template<typename InputIterator1,
 /*! \} // end prefix sums
  */
 
-	
+
 } // end namespace thrust
 
 #include <thrust/detail/scan.inl>

--- a/thrust/scan.h
+++ b/thrust/scan.h
@@ -349,7 +349,7 @@ __host__ __device__
  *  output sequences are the same, the scan is performed in-place.
  *
  *  Note that currently mixing scan input and output types can cause undefined behaviour.
- *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *  This issue can be avoided by supplying an initial value type argument to \p exclusive_scan.
  *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
@@ -398,7 +398,7 @@ template<typename InputIterator,
  *  output sequences are the same, the scan is performed in-place.
  *
  *  Note that currently mixing scan input and output types can cause undefined behaviour.
- *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *  This issue can be avoided by supplying an initial value type argument to \p exclusive_scan.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -458,7 +458,7 @@ __host__ __device__
  *  output sequences are the same, the scan is performed in-place.
  *
  *  Note that currently mixing scan input and output types can cause undefined behaviour.
- *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *  This issue can be avoided by supplying an initial value type argument to \p exclusive_scan.
  *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
@@ -509,7 +509,7 @@ template<typename InputIterator,
  *  sequences are the same, the scan is performed in-place.
  *
  *  Note that currently mixing scan input and output types can cause undefined behaviour.
- *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *  This issue can be avoided by supplying an initial value type argument to \p exclusive_scan.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -580,7 +580,7 @@ __host__ __device__
  *  sequences are the same, the scan is performed in-place.
  *
  *  Note that currently mixing scan input and output types can cause undefined behaviour.
- *  This issue can be avoided by supplying an initial value type argument to exclusive_scan.
+ *  This issue can be avoided by supplying an initial value type argument to \p exclusive_scan.
  *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.


### PR DESCRIPTION
Documentation for inclusive_scan() and exclusive_scan() updated.