### PR TITLE
Setup runtime and development packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,15 +32,8 @@ endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
 
-# rocm-cmake contains common cmake code for rocm projects to help
-# setup and install
-find_package( ROCM 0.6 CONFIG )
-include( ROCMSetupVersion )
-include( ROCMCreatePackage )
-include( ROCMInstallTargets )
-include( ROCMPackageConfigHelpers )
-include( ROCMInstallSymlinks )
-include( ROCMCheckTargetIds OPTIONAL )
+# Get dependencies
+include(cmake/Dependencies.cmake)
 
 # Detect compiler support for target ID
 # This section is deprecated. Please use rocm_check_target_ids for future use.
@@ -115,9 +108,6 @@ if(BUILD_ADDRESS_SANITIZER)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
   add_link_options(-fuse-ld=lld)
 endif()
-
-# Get dependencies
-include(cmake/Dependencies.cmake)
 
 # Setup VERSION
 rocm_setup_version(VERSION "2.10.9")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker searc
 
 # rocm-cmake contains common cmake code for rocm projects to help
 # setup and install
-find_package( ROCM CONFIG )
+find_package( ROCM 0.6 CONFIG )
 include( ROCMSetupVersion )
 include( ROCMCreatePackage )
 include( ROCMInstallTargets )
@@ -160,9 +160,9 @@ set(CPACK_RPM_PACKAGE_REQUIRES "rocprim >= 2.10.1")
 
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 
-if(NOT CPACK_PACKAGING_INSTALL_PREFIX)
-  set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-endif()
+# if(NOT CPACK_PACKAGING_INSTALL_PREFIX)
+#   set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+# endif()
 
 set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include")
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -60,3 +60,31 @@ if(BUILD_TEST)
   )
   find_package(GTest REQUIRED)
 endif()
+
+# Find or download/install rocm-cmake project
+find_package(ROCM 0.6 QUIET CONFIG PATHS /opt/rocm)
+if(NOT ROCM_FOUND)
+  message(STATUS "rocm-cmake not found. Downloading and building rocm-cmake.")
+  set(ROCM_CMAKE_ROOT ${CMAKE_CURRENT_BINARY_DIR}/deps/rocm-cmake CACHE PATH "")
+  download_project(
+      PROJ           rocm-cmake
+      GIT_REPOSITORY https://github.com/RadeonOpenCompute/rocm-cmake.git
+      GIT_TAG        master
+      INSTALL_DIR    ${ROCM_CMAKE_ROOT}
+      CMAKE_ARGS     -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+      LOG_DOWNLOAD   TRUE
+      LOG_CONFIGURE  TRUE
+      LOG_BUILD      TRUE
+      LOG_INSTALL    TRUE
+      BUILD_PROJECT  TRUE
+      ${UPDATE_DISCONNECTED_IF_AVAILABLE}
+    )
+  find_package(ROCM 0.6 REQUIRED CONFIG PATHS ${ROCM_CMAKE_ROOT})
+endif()
+
+include( ROCMSetupVersion )
+include( ROCMCreatePackage )
+include( ROCMInstallTargets )
+include( ROCMPackageConfigHelpers )
+include( ROCMInstallSymlinks )
+include( ROCMCheckTargetIds OPTIONAL )

--- a/cmake/ROCMExportTargetsHeaderOnly.cmake
+++ b/cmake/ROCMExportTargetsHeaderOnly.cmake
@@ -98,7 +98,7 @@ function(rocm_export_targets_header_only)
     endif()
 
     foreach(INCLUDE ${PARSE_INCLUDE})
-        install(FILES ${INCLUDE} DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
+        rocm_install(FILES ${INCLUDE} DESTINATION ${CONFIG_PACKAGE_INSTALL_DIR})
         get_filename_component(INCLUDE_BASE ${INCLUDE} NAME)
         rocm_write_package_template_function(${CONFIG_TEMPLATE} include "\${CMAKE_CURRENT_LIST_DIR}/${INCLUDE_BASE}")
     endforeach()
@@ -132,13 +132,13 @@ function(rocm_export_targets_header_only)
     if(PARSE_NAMESPACE)
         set(NAMESPACE_ARG "NAMESPACE;${PARSE_NAMESPACE}")
     endif()
-    install( EXPORT ${TARGET_FILE}
+    rocm_install( EXPORT ${TARGET_FILE}
         DESTINATION
         ${CONFIG_PACKAGE_INSTALL_DIR}
         ${NAMESPACE_ARG}
     )
 
-    install( FILES
+    rocm_install( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}-version.cmake
         DESTINATION

--- a/thrust/CMakeLists.txt
+++ b/thrust/CMakeLists.txt
@@ -42,7 +42,7 @@ if(CMAKE_VERSION VERSION_LESS 3.7)
   # if there are long file names.
   set(EXCLUDE_PATTERNS PATTERN "./system/cuda/detail/cub/*" EXCLUDE)
 endif()
-install(
+rocm_install(
   DIRECTORY
     "./"
     "${PROJECT_BINARY_DIR}/thrust/include/"


### PR DESCRIPTION
Switch installation from `install` to `rocm_install` to install to development package.

Update rocm-cmake to required version. In order for CMake to detect the version, rocm-cmake must be built and installed, here to a temporary directory.