### PR TITLE
HIP on Windows initial support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Full documentation for rocThrust is available at [https://rocthrust.readthedocs.io/en/latest/](https://rocthrust.readthedocs.io/en/latest/)
 
-## (Unreleased) rocThrust-2.11.2
+## (Unreleased) rocThrust-2.11.2 for ROCm 4.5.0
+### Addded
+- Initial HIP on Windows support. See README for instructions on how to build and install.
 ### Changed
-
 - Packaging split into a runtime package called rocthrust and a development package called rocthrust-devel. The development package depends on runtime. The runtime package suggests the development package for all supported OSes except CentOS 7 to aid in the transition. The suggests feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
 
 ## [Unreleased rocThrust-2.11.1 for ROCm 4.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Full documentation for rocThrust is available at [https://rocthrust.readthedocs.
 - Initial HIP on Windows support. See README for instructions on how to build and install.
 ### Changed
 - Packaging split into a runtime package called rocthrust and a development package called rocthrust-devel. The development package depends on runtime. The runtime package suggests the development package for all supported OSes except CentOS 7 to aid in the transition. The suggests feature in packaging is introduced as a deprecated feature and will be removed in a future rocm release.
+### Known issues
+- async_copy, partition, and stable_sort_by_key unit tests are failing on HIP on Windows.
 
 ## [Unreleased rocThrust-2.11.1 for ROCm 4.4.0]
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,9 @@ add_subdirectory(thrust)
 # Tests
 if(BUILD_TEST)
   # We still want the testing to be compiled to catch some errors
-  #add_subdirectory(testing)
+  #TODO: Get testing folder working with HIP on Windows
+  if (NOT WIN32)
+    add_subdirectory(testing)
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,15 +32,6 @@ endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
 
-# rocm-cmake contains common cmake code for rocm projects to help
-# setup and install
-find_package( ROCM CONFIG )
-include( ROCMSetupVersion )
-include( ROCMCreatePackage )
-include( ROCMInstallTargets )
-include( ROCMPackageConfigHelpers )
-include( ROCMInstallSymlinks )
-include( ROCMCheckTargetIds OPTIONAL )
 
 # Detect compiler support for target ID
 # This section is deprecated. Please use rocm_check_target_ids for future use.
@@ -68,8 +59,9 @@ endif()
 set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
 
 # Verify that hcc or hipcc compiler is used on ROCM platform
-include(cmake/VerifyCompiler.cmake)
-
+if (NOT WIN32)
+  include(cmake/VerifyCompiler.cmake)
+endif()
 # Build options
 # Disable -Werror
 option(DISABLE_WERROR "Disable building with Werror" ON)
@@ -102,12 +94,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(DISABLE_WERROR)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra ")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --save-temps")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --save-temps -std=c++14")
+
+if (WIN32)
+  add_compile_options(-xhip)
+  add_compile_definitions(THRUST_IGNORE_DEPRECATED_CPP_DIALECT)
+endif()
 
 # Address Sanitizer
 if(BUILD_ADDRESS_SANITIZER)
@@ -132,7 +129,7 @@ add_subdirectory(thrust)
 # Tests
 if(BUILD_TEST)
   # We still want the testing to be compiled to catch some errors
-  add_subdirectory(testing)
+  #add_subdirectory(testing)
   enable_testing()
   add_subdirectory(test)
 endif()

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Thrust is a parallel algorithm library. This library has been ported to [HIP](ht
     set as C++ compiler on ROCm platform.
 * [rocPRIM](https://github.com/ROCmSoftwarePlatform/rocPRIM) library
   * It will be automatically downloaded and built by CMake script.
+* Python 3.6 or higher (HIP on Windows only)
+* Visual Studio 2019 with clang support (HIP on Windows only)
+* Strawberry Perl (HIP on Windows only)
 
 Optional:
 
@@ -64,6 +67,20 @@ make package
 
 # Install
 [sudo] make install
+```
+
+### HIP on Windows
+
+Initial support for HIP on Windows has been added.  To install, use the provided rmake.py python script:
+```shell
+git clone https://github.com/ROCmSoftwarePlatform/rocThrust.git
+cd rocThrust
+
+# the -i option will install rocPRIM to C:\hipSDK by default
+python rmake.py -i
+
+# the -c option will build all clients including unit tests
+python rmake.py -c
 ```
 
 ### Macro options

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Thrust is a parallel algorithm library. This library has been ported to [HIP](ht
     set as C++ compiler on ROCm platform.
 * [rocPRIM](https://github.com/ROCmSoftwarePlatform/rocPRIM) library
   * It will be automatically downloaded and built by CMake script.
-* Python 3.6 or higher (HIP on Windows only)
+* Python 3.6 or higher (HIP on Windows only, only required for install scripts)
 * Visual Studio 2019 with clang support (HIP on Windows only)
 * Strawberry Perl (HIP on Windows only)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -42,21 +42,64 @@ endif()
 
 # Test dependencies
 if(BUILD_TEST)
-  # Google Test (https://github.com/google/googletest)
-  message(STATUS "Downloading and building GTest.")
-  set(GTEST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/gtest CACHE PATH "")
-  download_project(
-    PROJ                googletest
-    GIT_REPOSITORY      https://github.com/google/googletest.git
-    GIT_TAG             release-1.8.1
-    INSTALL_DIR         ${GTEST_ROOT}
-    CMAKE_ARGS          -DBUILD_GTEST=ON -DINSTALL_GTEST=ON -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    LOG_DOWNLOAD        TRUE
-    LOG_CONFIGURE       TRUE
-    LOG_BUILD           TRUE
-    LOG_INSTALL         TRUE
-    BUILD_PROJECT       TRUE
-    UPDATE_DISCONNECTED TRUE
-  )
-  find_package(GTest REQUIRED)
+  find_package(GTest QUIET)
+  
+  if(NOT TARGET GTest::GTest AND NOT TARGET GTest::gtest)
+    message(STATUS "GTest not found or force download GTest on. Downloading and building GTest.")
+    set(GTEST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/deps/gtest CACHE PATH "")  
+
+    download_project(
+      PROJ                googletest
+      GIT_REPOSITORY      https://github.com/google/googletest.git
+      GIT_TAG             release-1.8.1
+      INSTALL_DIR         ${GTEST_ROOT}
+      CMAKE_ARGS          -DBUILD_GTEST=ON -DINSTALL_GTEST=ON -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+      LOG_DOWNLOAD        TRUE
+      LOG_CONFIGURE       TRUE
+      LOG_BUILD           TRUE
+      LOG_INSTALL         TRUE
+      BUILD_PROJECT       TRUE
+      UPDATE_DISCONNECTED TRUE
+    )
+    list( APPEND CMAKE_PREFIX_PATH ${GTEST_ROOT} )    
+    find_package(GTest REQUIRED)
+  endif()
 endif()
+
+find_package(ROCM QUIET CONFIG PATHS /opt/rocm)
+if(NOT ROCM_FOUND)
+  set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
+  file(
+    DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
+    ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+    STATUS rocm_cmake_download_status LOG rocm_cmake_download_log
+  )
+  list(GET rocm_cmake_download_status 0 rocm_cmake_download_error_code)
+  if(rocm_cmake_download_error_code)
+    message(FATAL_ERROR "Error: downloading "
+      "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip failed "
+      "error_code: ${rocm_cmake_download_error_code} "
+      "log: ${rocm_cmake_download_log} "
+    )
+  endif()
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    RESULT_VARIABLE rocm_cmake_unpack_error_code
+  )
+  if(rocm_cmake_unpack_error_code)
+    message(FATAL_ERROR "Error: unpacking  ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
+  endif()
+  find_package(ROCM REQUIRED CONFIG PATHS ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag})
+endif()
+
+# rocm-cmake contains common cmake code for rocm projects to help
+# setup and install
+find_package( ROCM CONFIG )
+include( ROCMSetupVersion )
+include( ROCMCreatePackage )
+include( ROCMInstallTargets )
+include( ROCMPackageConfigHelpers )
+include( ROCMInstallSymlinks )
+include( ROCMCheckTargetIds OPTIONAL )

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -51,7 +51,7 @@ if(BUILD_TEST)
     download_project(
       PROJ                googletest
       GIT_REPOSITORY      https://github.com/google/googletest.git
-      GIT_TAG             release-1.8.1
+      GIT_TAG             release-1.10.0
       INSTALL_DIR         ${GTEST_ROOT}
       CMAKE_ARGS          -DBUILD_GTEST=ON -DINSTALL_GTEST=ON -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
       LOG_DOWNLOAD        TRUE

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -43,10 +43,10 @@ endif()
 # Test dependencies
 if(BUILD_TEST)
   find_package(GTest QUIET)
-  
+
   if(NOT TARGET GTest::GTest AND NOT TARGET GTest::gtest)
     message(STATUS "GTest not found or force download GTest on. Downloading and building GTest.")
-    set(GTEST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/deps/gtest CACHE PATH "")  
+    set(GTEST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/deps/gtest CACHE PATH "")
 
     download_project(
       PROJ                googletest
@@ -61,43 +61,39 @@ if(BUILD_TEST)
       BUILD_PROJECT       TRUE
       UPDATE_DISCONNECTED TRUE
     )
-    list( APPEND CMAKE_PREFIX_PATH ${GTEST_ROOT} )    
+    list( APPEND CMAKE_PREFIX_PATH ${GTEST_ROOT} )
     find_package(GTest REQUIRED)
   endif()
 endif()
 
-find_package(ROCM QUIET CONFIG PATHS /opt/rocm)
-if(NOT ROCM_FOUND)
-  set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
-  file(
-    DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
-    ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-    STATUS rocm_cmake_download_status LOG rocm_cmake_download_log
-  )
-  list(GET rocm_cmake_download_status 0 rocm_cmake_download_error_code)
-  if(rocm_cmake_download_error_code)
-    message(FATAL_ERROR "Error: downloading "
-      "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip failed "
-      "error_code: ${rocm_cmake_download_error_code} "
-      "log: ${rocm_cmake_download_log} "
-    )
-  endif()
-
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    RESULT_VARIABLE rocm_cmake_unpack_error_code
-  )
-  if(rocm_cmake_unpack_error_code)
-    message(FATAL_ERROR "Error: unpacking  ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
-  endif()
-  find_package(ROCM REQUIRED CONFIG PATHS ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag})
-endif()
-
-# rocm-cmake contains common cmake code for rocm projects to help
-# setup and install
 if (WIN32)
-  find_package( ROCM CONFIG )
+    find_package(ROCM QUIET CONFIG PATHS /opt/rocm)
+    if(NOT ROCM_FOUND)
+      set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
+      file(
+        DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
+        ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+        STATUS rocm_cmake_download_status LOG rocm_cmake_download_log
+      )
+      list(GET rocm_cmake_download_status 0 rocm_cmake_download_error_code)
+      if(rocm_cmake_download_error_code)
+        message(FATAL_ERROR "Error: downloading "
+          "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip failed "
+          "error_code: ${rocm_cmake_download_error_code} "
+          "log: ${rocm_cmake_download_log} "
+        )
+      endif()
+
+      execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        RESULT_VARIABLE rocm_cmake_unpack_error_code
+      )
+      if(rocm_cmake_unpack_error_code)
+        message(FATAL_ERROR "Error: unpacking  ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
+      endif()
+      find_package(ROCM REQUIRED CONFIG PATHS ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag})
+    endif()
 else()
   # Find or download/install rocm-cmake project
   find_package(ROCM 0.6 QUIET CONFIG PATHS /opt/rocm)
@@ -121,6 +117,8 @@ else()
   endif()
 endif()
 
+# rocm-cmake contains common cmake code for rocm projects to help
+# setup and install
 include( ROCMSetupVersion )
 include( ROCMCreatePackage )
 include( ROCMInstallTargets )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,7 +32,9 @@ function(add_thrust_example EXAMPLE)
         PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/"
     )
-    if (WIN32 AND NOT DLLS_COPIED)
+    if (WIN32 AND NOT DEFINED DLLS_COPIED)
+      set(DLLS_COPIED "YES")
+
       # for now adding in all .dll as dependency chain is not cmake based on win32
       file( GLOB third_party_dlls
       LIST_DIRECTORIES ON
@@ -41,10 +43,9 @@ function(add_thrust_example EXAMPLE)
       ${CMAKE_SOURCE_DIR}/rtest.*
       )
       foreach( file_i ${third_party_dlls})
-      add_custom_command( TARGET ${EXAMPLE_TARGET} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/examples )
+        add_custom_command( TARGET ${EXAMPLE_TARGET} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${file_i} ${PROJECT_BINARY_DIR}/examples )
       endforeach( file_i )
-      set(DLLS_COPIED ON)
-    endif()      
+    endif()         
 endfunction()
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,10 @@
 # Copyright 2020 Advanced Micro Devices, Inc.
 # ########################################################################
 
+if (WIN32)
+  set(DLLS_COPIED OFF)
+endif()
+
 function(add_thrust_example EXAMPLE)
     set(EXAMPLE_SOURCE "${EXAMPLE}.cu")
     set(EXAMPLE_TARGET "example_thrust_${EXAMPLE}")
@@ -16,16 +20,31 @@ function(add_thrust_example EXAMPLE)
             rocthrust
             roc::rocprim_hip
     )
-    foreach(amdgpu_target ${AMDGPU_TARGETS})
-        target_link_libraries(${EXAMPLE_TARGET}
-            INTERFACE
-                --cuda-gpu-arch=${amdgpu_target}
-        )
-    endforeach()
+    if (NOT WIN32)
+      foreach(amdgpu_target ${AMDGPU_TARGETS})
+          target_link_libraries(${EXAMPLE_TARGET}
+              INTERFACE
+                  --cuda-gpu-arch=${amdgpu_target}
+          )
+      endforeach()
+    endif()
     set_target_properties(${EXAMPLE_TARGET}
         PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/"
     )
+    if (WIN32 AND NOT DLLS_COPIED)
+      # for now adding in all .dll as dependency chain is not cmake based on win32
+      file( GLOB third_party_dlls
+      LIST_DIRECTORIES ON
+      CONFIGURE_DEPENDS
+      ${HIP_DIR}/bin/*.dll
+      ${CMAKE_SOURCE_DIR}/rtest.*
+      )
+      foreach( file_i ${third_party_dlls})
+      add_custom_command( TARGET ${EXAMPLE_TARGET} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/examples )
+      endforeach( file_i )
+      set(DLLS_COPIED ON)
+    endif()      
 endfunction()
 
 

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -74,11 +74,13 @@ function(add_rocthrust_test TEST_NAME TEST_SOURCES)
     PRIVATE
       ${rocthrust_LIBRARIES} # rocthrust
   )
-  foreach(amdgpu_target ${AMDGPU_TARGETS})
-    target_link_libraries(${TEST_TARGET}
-      PRIVATE
-        --amdgpu-target=${amdgpu_target}
-    )
+  if (NOT WIN32)
+    foreach(amdgpu_target ${AMDGPU_TARGETS})
+      target_link_libraries(${TEST_TARGET}
+        PRIVATE
+          --amdgpu-target=${amdgpu_target}
+      )
+  endif()
   endforeach()
   add_test(${TEST_NAME} ${TEST_TARGET})
 endfunction()

--- a/rdeps.py
+++ b/rdeps.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+# Copyright 2021 Advanced Micro Devices, Inc.
+
+"""Manage dependency installation"""
+
+import os
+import sys
+import subprocess
+import argparse
+import pathlib
+import shutil
+import platform
+
+def install_conan(**kwargs):
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'conan'])
+
+def configure_conan(profile, **kwargs):
+    subprocess.call(['conan', 'profile', 'new', profile, '--detect'])
+    if platform.system() == 'Linux':
+        subprocess.check_call(['conan', 'profile', 'update',
+            'settings.compiler.libcxx=libstdc++11', profile])
+
+def conan_install_deps(install_dir, profile='default', **kwargs):
+    source_dir = os.path.dirname(os.path.realpath(__file__))
+    subprocess.check_call(['conan', 'install', source_dir, '-o', 'clients=True',
+        '--install-folder={}'.format(install_dir), '--build=missing', '--profile', profile])
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Manage dependency installation')
+    parser.add_argument(      '--install_dir', type=str, required=False, default="build\\deps",
+                        help='The install directory path (optional, default: build\\deps)')
+    # parser.add_argument('-v', '--verbose', required=False, default=False, action='store_true',
+    #                     help='Verbose install')
+    return parser.parse_args()
+
+def os_detect():
+    info = {}
+    try:
+        with open('/etc/os-release') as f:
+            for line in f:
+                if '=' in line:
+                    k,v = line.strip().split('=', maxsplit=1)
+                    info[k] = v.replace('"', '')
+    except OSError as e:
+        info["ID"] = platform.system()
+    info["NUM_PROC"] = os.cpu_count()
+    return info
+
+def install_deps(**kwargs):
+    install_conan(**kwargs)
+    configure_conan(**kwargs)
+    conan_install_deps(**kwargs)
+
+def main():
+    args = parse_args()
+    print(os_detect())
+    install_deps(install_dir=args.install_dir, profile='rocm')
+
+if __name__ == '__main__':
+    main()

--- a/rmake.py
+++ b/rmake.py
@@ -1,0 +1,223 @@
+#!/usr/bin/python3
+"""Copyright 2020-2021 Advanced Micro Devices, Inc.
+Manage build and installation"""
+
+import re
+import sys
+import os
+import subprocess
+import argparse
+import ctypes
+import pathlib
+from fnmatch import fnmatchcase
+
+args = {}
+param = {}
+OS_info = {}
+
+def parse_args():
+    """Parse command-line arguments"""
+    parser = argparse.ArgumentParser(description="""
+    Checks build arguments
+    """)
+    parser.add_argument('-g', '--debug', required=False, default=False,  action='store_true',
+                        help='Generate Debug build (default: False)')
+    parser.add_argument(      '--build_dir', type=str, required=False, default="build",
+                        help='Build directory path (default: build)')
+    parser.add_argument(      '--deps_dir', type=str, required=False, default=None,
+                        help='Dependencies directory path (default: build/deps)')
+    parser.add_argument(      '--skip_ld_conf_entry', required=False, default=False)
+    parser.add_argument(      '--static', required=False, default=False, dest='static_lib', action='store_true',
+                        help='Generate static library build (default: False)')
+    parser.add_argument('-c', '--clients', required=False, default=False, dest='build_clients', action='store_true',
+                        help='Generate all client builds (default: False)')
+    parser.add_argument('-i', '--install', required=False, default=False, dest='install', action='store_true',
+                        help='Install after build (default: False)')
+    parser.add_argument(      '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
+                        help='List of additional cmake defines for builds (e.g. CMAKE_CXX_COMPILER_LAUNCHER=ccache)')
+    parser.add_argument('-a', '--architecture', dest='gpu_architecture', required=False, default="gfx906", #:sramecc+:xnack-" ) #gfx1030" ) #gfx906" ) # gfx1030" )
+                        help='Set GPU architectures, e.g. all, gfx000, gfx803, gfx906:xnack-;gfx1030 (optional, default: all)')                        
+    parser.add_argument('-v', '--verbose', required=False, default=False, action='store_true',
+                        help='Verbose build (default: False)')
+    return parser.parse_args()
+
+def os_detect():
+    inf_file = "/etc/os-release"
+    if os.path.exists(inf_file):
+        with open(inf_file) as f:
+            for line in f:
+                if "=" in line:
+                    k,v = line.strip().split("=")
+                    OS_info[k] = v.replace('"','')
+    else:
+        OS_info["ID"] = 'windows'
+        OS_info["VERSION_ID"] = 10
+    OS_info["NUM_PROC"] = os.cpu_count()
+    print(OS_info)
+
+def create_dir(dir_path):
+    if os.path.isabs(dir_path):
+        full_path = dir_path
+    else:
+        fullpath = os.path.join( os.getcwd(), dir_path )
+    pathlib.Path(fullpath).mkdir(parents=True, exist_ok=True)
+    return
+
+def delete_dir(dir_path) :
+    if (not os.path.exists(dir_path)):
+        return
+    if (OS_info["ID"] == 'windows'):
+        run_cmd( "RMDIR" , f"/S /Q {dir_path}")
+    else:
+        linux_path = pathlib.Path(dir_path).absolute()
+        #print( linux_path )
+        run_cmd( "rm" , f"-rf {linux_path}")
+
+def config_cmd():
+    global args
+    global OS_info
+    cwd_path = os.getcwd()
+    src_path = cwd_path.replace("\\", "/")
+
+    print( f"***************** {src_path}")
+    cmake_executable = ""
+    cmake_options = []
+    cmake_platform_opts = []
+    if (OS_info["ID"] == 'windows'):
+        # we don't have ROCM on windows but have hip, ROCM can be downloaded if required
+        rocm_path = os.getenv( 'ROCM_PATH', "C:/hipsdk/rocm-cmake-master") #C:/hip") # rocm/Utils/cmake-rocm4.2.0"
+        cmake_executable = "cmake.exe"
+        toolchain = os.path.join( src_path, "toolchain-windows.cmake" )
+        #set CPACK_PACKAGING_INSTALL_PREFIX= defined as blank as it is appended to end of path for archive creation
+        cmake_platform_opts.append( f"-DWIN32=ON -DCPACK_PACKAGING_INSTALL_PREFIX=""") #" -DCPACK_PACKAGING_INSTALL_PREFIX={rocm_path}"
+        cmake_platform_opts.append( f"-DCMAKE_INSTALL_PREFIX=\"C:/hipSDK\" -DCPACK_PACKAGE_INSTALL_DIRECTORY=\"rocrand\"")        
+        generator = f"-G Ninja"
+        # "-G \"Visual Studio 16 2019\" -A x64"  #  -G NMake ")  #
+        cmake_options.append( generator )
+    else:
+        rocm_path = os.getenv( 'ROCM_PATH', "/opt/rocm")
+        if (OS_info["ID"] in ['centos', 'rhel']):
+          cmake_executable = "cmake3"
+        else:
+          cmake_executable = "cmake"
+        toolchain = "toolchain-linux.cmake"
+        cmake_platform_opts = f"-DROCM_DIR:PATH={rocm_path} -DCPACK_PACKAGING_INSTALL_PREFIX={rocm_path}"
+
+    tools = f"-DCMAKE_TOOLCHAIN_FILE={toolchain}"
+    cmake_options.append( tools )
+
+    cmake_options.extend( cmake_platform_opts)
+
+
+  # build type
+    cmake_config = ""
+    build_dir = args.build_dir
+    if not args.debug:
+        build_path = os.path.join(build_dir, "release")
+        cmake_config="Release"
+    else:
+        build_path = os.path.join(build_dir, "debug")
+        cmake_config="Debug"
+
+    cmake_options.append( f"-DCMAKE_BUILD_TYPE={cmake_config}" ) #--build {build_path}" )
+
+    if args.deps_dir is None:
+        deps_dir = os.path.abspath(os.path.join(build_dir, 'deps')).replace('\\','/')
+    else:
+        deps_dir = args.deps_dir
+    cmake_base_options = f"-DROCM_PATH={rocm_path} -DCMAKE_PREFIX_PATH:PATH={rocm_path}" # -DCMAKE_INSTALL_PREFIX=rocmath-install" #-DCMAKE_INSTALL_LIBDIR=
+    cmake_options.append( cmake_base_options )
+
+    print( cmake_options )
+
+    # clean
+    delete_dir( build_path )
+
+    create_dir( os.path.join(build_path, "clients") )
+    os.chdir( build_path )
+
+    if args.static_lib:
+        cmake_options.append( f"-DBUILD_SHARED_LIBS=OFF" )
+
+    if args.skip_ld_conf_entry:
+        cmake_options.append( f"-DROCM_DISABLE_LDCONFIG=ON" )
+
+    if args.build_clients:
+        cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_DIR={build_dir}" )
+
+    cmake_options.append( f"-DAMDGPU_TARGETS={args.gpu_architecture}" )
+    
+    if args.cmake_dargs:
+        for i in args.cmake_dargs:
+          cmake_options.append( f"-D{i}" )
+
+    cmake_options.append( f"{src_path}")
+
+#   case "${ID}" in
+#     centos|rhel)
+#     cmake_options="${cmake_options} -DCMAKE_FIND_ROOT_PATH=/usr/lib64/llvm7.0/lib/cmake/"
+#     ;;
+#     windows)
+#     cmake_options="${cmake_options} -DWIN32=ON -DROCM_PATH=${rocm_path} -DROCM_DIR:PATH=${rocm_path} -DCMAKE_PREFIX_PATH:PATH=${rocm_path}"
+#     cmake_options="${cmake_options} --debug-trycompile -DCMAKE_MAKE_PROGRAM=nmake.exe -DCMAKE_TOOLCHAIN_FILE=toolchain-windows.cmake"
+#     # -G '"NMake Makefiles JOM"'"
+#     ;;
+#   esac
+    cmd_opts = " ".join(cmake_options)
+
+    return cmake_executable, cmd_opts
+
+
+def make_cmd():
+    global args
+    global OS_info
+
+    make_options = []
+
+    if (OS_info["ID"] == 'windows'):
+        make_executable = "cmake.exe --build ." # ninja"
+        if args.verbose:
+          make_options.append( "--verbose" )
+        make_options.append( "--target all" )
+        if args.install:
+          make_options.append( "--target package --target install" )
+    else:
+        nproc = OS_info["NUM_PROC"]
+        make_executable = f"make -j{nproc}"
+        if args.verbose:
+          make_options.append( "VERBOSE=1" )
+        if args.install:
+          make_options.append( "install" )
+    cmd_opts = " ".join(make_options)
+
+    return make_executable, cmd_opts
+
+def run_cmd(exe, opts):
+    program = f"{exe} {opts}"
+    if sys.platform.startswith('win'):
+        sh = True
+    else:
+        sh = True
+    print(program)
+    proc = subprocess.run(program, check=True, stderr=subprocess.STDOUT, shell=sh)
+    #proc = subprocess.Popen(cmd, cwd=os.getcwd())
+    #cwd=os.path.join(workingdir,"..",".."), stdout=fout, stderr=fout,
+     #                       env=os.environ.copy())
+    #proc.wait()
+    return proc.returncode
+
+def main():
+    global args
+    os_detect()
+    args = parse_args()
+    # configure
+    exe, opts = config_cmd()
+    run_cmd(exe, opts)
+
+    # make/build/install
+    exe, opts = make_cmd()
+    run_cmd(exe, opts)
+
+
+if __name__ == '__main__':
+    main()

--- a/rtest.py
+++ b/rtest.py
@@ -1,0 +1,310 @@
+#!/usr/bin/python3
+"""Copyright 2021 Advanced Micro Devices, Inc.
+Run tests on build"""
+
+import re
+import os
+import sys
+import subprocess
+import shlex
+import argparse
+import pathlib
+import platform
+from genericpath import exists
+from fnmatch import fnmatchcase
+from xml.dom import minidom
+import multiprocessing
+import time
+
+args = {}
+OS_info = {}
+
+timeout = False
+test_proc = None
+stop = 0
+
+test_script = [ 'cd %IDIR%', '%XML%' ]
+
+def parse_args():
+    """Parse command-line arguments"""
+    parser = argparse.ArgumentParser(description="""
+    Checks build arguments
+    """)
+    parser.add_argument('-t', '--test', required=True, 
+                        help='Test set to run from rtest.xml (required, e.g. osdb)')
+    parser.add_argument('-g', '--debug', required=False, default=False,  action='store_true',
+                        help='Test Debug build (optional, default: false)')
+    parser.add_argument('-o', '--output', type=str, required=False, default="xml", 
+                        help='Test output file (optional, default: test_detail.xml)')
+    parser.add_argument(      '--install_dir', type=str, required=False, default="build", 
+                        help='Installation directory where build or release folders are (optional, default: build)')
+    parser.add_argument(      '--fail_test', default=False, required=False, action='store_true',
+                        help='Return as if test failed (optional, default: false)')
+    # parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
+    #                     help='Verbose install (optional, default: False)')
+    return parser.parse_args()
+
+
+def vram_detect():
+    global OS_info
+    OS_info["VRAM"] = 0
+    if os.name == "nt":
+        cmd = "hipinfo.exe"
+        process = subprocess.run([cmd], stdout=subprocess.PIPE)
+        for line_in in process.stdout.decode().splitlines():
+            if 'totalGlobalMem' in line_in:
+                OS_info["VRAM"] = float(line_in.split()[1])
+                break
+    else:
+        cmd = "rocminfo"
+        process = subprocess.run([cmd], stdout=subprocess.PIPE)
+        for line_in in process.stdout.decode().splitlines():
+            match = re.search(r'.*Size:.*([0-9]+)\(.*\).*KB', line_in, re.IGNORECASE)
+            if match:
+                OS_info["VRAM"] = float(match.group(1))/(1024*1024)
+                break
+
+def os_detect():
+    global OS_info
+    if os.name == "nt":
+        OS_info["ID"] = platform.system()
+    else:
+        inf_file = "/etc/os-release"
+        if os.path.exists(inf_file):
+            with open(inf_file) as f:
+                for line in f:
+                    if "=" in line:
+                        k,v = line.strip().split("=")
+                        OS_info[k] = v.replace('"','')
+    OS_info["NUM_PROC"] = os.cpu_count()
+    vram_detect()
+    print(OS_info)
+
+
+def create_dir(dir_path):
+    if os.path.isabs(dir_path):
+        full_path = dir_path
+    else:
+        full_path = os.path.join( os.getcwd(), dir_path )
+    return pathlib.Path(full_path).mkdir(parents=True, exist_ok=True)
+
+def delete_dir(dir_path) :
+    if (not os.path.exists(dir_path)):
+        return
+    if os.name == "nt":
+        return run_cmd( "RMDIR" , f"/S /Q {dir_path}")
+    else:
+        linux_path = pathlib.Path(dir_path).absolute()
+        return run_cmd( "rm" , f"-rf {linux_path}")
+
+class TimerProcess(multiprocessing.Process):
+
+    def __init__(self, start, stop, kill_pid):
+        multiprocessing.Process.__init__(self)
+        self.quit = multiprocessing.Event()
+        self.timed_out = multiprocessing.Event()
+        self.start_time = start
+        self.max_time = stop
+        self.kill_pid = kill_pid
+
+    def run(self):
+        while not self.quit.is_set():
+            #print( f'time_stop {self.start_time} limit {self.max_time}')
+            if (self.max_time == 0):
+                return
+            t = time.monotonic()
+            if ( t - self.start_time > self.max_time ):
+                print( f'killing {self.kill_pid} t {t}')
+                if os.name == "nt":
+                    cmd = ['TASKKILL', '/F', '/T', '/PID', str(self.kill_pid)]
+                    proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+                else:
+                    os.kill(self.kill_pid, signal.SIGKILL)  
+                self.timed_out.set()
+                self.stop()
+            pass
+
+    def stop(self):
+        self.quit.set()
+    
+    def stopped(self):
+        return self.timed_out.is_set()
+
+
+def time_stop(start, pid):
+    global timeout, stop
+    while (True):
+        print( f'time_stop {start} limit {stop}')
+        t = time.monotonic()
+        if (stop == 0):
+            return
+        if ( (stop > 0) and (t - start > stop) ):
+            print( f'killing {pid} t {t}')
+            if os.name == "nt":
+                cmd = ['TASKKILL', '/F', '/T', '/PID', str(pid)]
+                proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+            else:
+                test_proc.kill()
+            timeout = True
+            stop = 0
+        time.sleep(0)
+
+def run_cmd(cmd, test = False, time_limit = 0):
+    global args
+    global test_proc, timer_thread
+    global stop
+    if (cmd.startswith('cd ')):
+        return os.chdir(cmd[3:])
+    if (cmd.startswith('mkdir ')):
+        return create_dir(cmd[6:])
+    cmdline = f"{cmd}"
+    print(cmdline)
+    try:
+        if not test:
+            proc = subprocess.run(cmdline, check=True, stderr=subprocess.STDOUT, shell=True)
+            status = proc.returncode
+        else:
+            error = False
+            timeout = False
+            test_proc = subprocess.Popen(shlex.split(cmdline), text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+            if time_limit > 0:
+                start = time.monotonic()
+                #p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
+                p = TimerProcess(start, time_limit, test_proc.pid)
+                p.start()
+            while True:
+                output = test_proc.stdout.readline()
+                if output == '' and test_proc.poll() is not None:
+                    break
+                elif output:
+                    outstring = output.strip()
+                    print (outstring)
+                    error = error or re.search(r'FAILED', outstring)
+            status = test_proc.poll()
+            if time_limit > 0:
+                p.stop()
+                p.join()
+                timeout = p.stopped()
+                print(f"timeout {timeout}")
+            if error: 
+                status = 1
+            elif timeout:
+                status = 2
+            else:
+                status = test_proc.returncode    
+    except:
+        import traceback
+        exc = traceback.format_exc()
+        print( "Python Exception: {0}".format(exc) )
+        status = 3
+    return status
+
+def batch(script, xml):
+    global OS_info
+    global args
+    # 
+    cwd = pathlib.os.curdir
+    rtest_cwd_path = os.path.abspath( os.path.join( cwd, 'rtest.xml') )
+    if os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith( "staging" ):
+        # if in a staging directory then test locally
+        test_dir = cwd 
+    else:
+        if args.debug: build_type = "debug"
+        else: build_type = "release"
+        test_dir = f"{args.install_dir}//{build_type}//test"
+    fail = False
+    for i in range(len(script)):
+        cmdline = script[i]
+        xcmd = cmdline.replace('%IDIR%', test_dir)
+        cmd = xcmd.replace('%ODIR%', args.output)
+        if cmd.startswith('tdir '):
+            if pathlib.Path(cmd[5:]).exists():
+                return 0 # all further cmds skipped
+            else:
+                continue
+        error = False
+        if cmd.startswith('%XML%'):
+            # run the matching tests listed in the xml test file
+            var_subs = {}
+            for var in xml.getElementsByTagName('var'):
+                name = var.getAttribute('name')
+                val = var.getAttribute('value')
+                var_subs[name] = val
+            for test in xml.getElementsByTagName('test'):
+                sets = test.getAttribute('sets')
+                runset = sets.split(',')
+                if args.test in runset:
+                    for run in test.getElementsByTagName('run'):
+                        name = run.getAttribute('name')
+                        vram_limit = run.getAttribute('vram_min')
+                        if vram_limit:
+                            if OS_info["VRAM"] < float(vram_limit):
+                                print( f'***\n*** Skipped: {name} due to VRAM req.\n***')
+                                continue
+                        if name:
+                            print( f'***\n*** Running: {name}\n***')
+                        time_limit = run.getAttribute('time_max')
+                        if time_limit:
+                            timeout = float(time_limit)
+                        else:
+                            timeout = 0
+
+                        raw_cmd = run.firstChild.data
+                        var_cmd = raw_cmd.format_map(var_subs)
+                        error = run_cmd(var_cmd, True, timeout)
+                        if (error == 2):
+                            print( f'***\n*** Timed out when running: {name}\n***')
+        else:
+            error = run_cmd(cmd)
+        fail = fail or error
+
+    if (fail):
+        if (cmd == "%XML%"):
+            print(f"FAILED xml test suite!")
+        else:
+            print(f"ERROR running: {cmd}")
+        if (os.curdir != cwd):
+            os.chdir( cwd )
+        return 1
+    if (os.curdir != cwd):
+        os.chdir( cwd )
+    return 0
+
+def run_tests():
+    global test_script
+    global xmlDoc
+
+    # install
+    cwd = os.curdir
+
+    xmlPath = os.path.join( cwd, 'rtest.xml')
+    xmlDoc = minidom.parse( xmlPath )
+
+    scripts = []
+    scripts.append( test_script )
+    for i in scripts:
+        if (batch(i, xmlDoc)):
+            #print("Failure in script. ABORTING")
+            if (os.curdir != cwd):
+                os.chdir( cwd )
+            return 1       
+    if (os.curdir != cwd):
+        os.chdir( cwd )
+    return 0
+
+def main():
+    global args
+    global timer_thread
+
+    os_detect()
+    args = parse_args()
+
+    status = run_tests()
+
+    if args.fail_test: status = 1
+
+    if (status):
+        sys.exit(status)
+
+if __name__ == '__main__':
+    main()

--- a/rtest.xml
+++ b/rtest.xml
@@ -1,0 +1,9 @@
+<testset>
+<var name="CTEST_FILTER" value="ctest --output-on-failure --exclude-regex "></var>
+<test sets="psdb">
+  <run name="all_tests">{CTEST_FILTER} async_copy.hip partition.hip stable_sort_by_key_large.hip</run>
+</test>
+<test sets="osdb">
+  <run name="all_tests">{CTEST_FILTER} async_copy.hip partition.hip stable_sort_by_key_large.hip</run>
+</test>
+</testset>

--- a/rtest.xml
+++ b/rtest.xml
@@ -1,9 +1,10 @@
-<testset>
-<var name="CTEST_FILTER" value="ctest --output-on-failure --exclude-regex "></var>
+<?xml version="1.0" encoding="UTF-8"?>
+<testset failure-regex="[1-9]\d* tests failed">
+<var name="CTEST_FILTER" value="ctest --output-on-failure"></var>
 <test sets="psdb">
-  <run name="all_tests">{CTEST_FILTER} async_copy.hip partition.hip stable_sort_by_key_large.hip</run>
+  <run name="all_tests">{CTEST_FILTER}</run>
 </test>
 <test sets="osdb">
-  <run name="all_tests">{CTEST_FILTER} async_copy.hip partition.hip stable_sort_by_key_large.hip</run>
+  <run name="all_tests">{CTEST_FILTER}</run>
 </test>
 </testset>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,10 +26,6 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/test_seed.hpp
 )
 
-if (WIN32)
-  set(DLLS_COPIED OFF)
-endif()
-
 function(add_rocthrust_test TEST)
     set(TEST_SOURCE "test_${TEST}.cpp")
     set(TEST_TARGET "${TEST}.hip")
@@ -73,7 +69,9 @@ function(add_rocthrust_test TEST)
                 LABELS "hip"
         )
     endif()
-    if (WIN32 AND NOT DLLS_COPIED)
+    if (WIN32 AND NOT DEFINED DLLS_COPIED)
+      set(DLLS_COPIED "YES")
+      
       # for now adding in all .dll as dependency chain is not cmake based on win32
       file( GLOB third_party_dlls
       LIST_DIRECTORIES ON
@@ -82,10 +80,9 @@ function(add_rocthrust_test TEST)
       ${CMAKE_SOURCE_DIR}/rtest.*
       )
       foreach( file_i ${third_party_dlls})
-      add_custom_command( TARGET ${TEST_TARGET} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/test )
+        add_custom_command( TARGET ${TEST_TARGET} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${file_i} ${PROJECT_BINARY_DIR}/test )
       endforeach( file_i )
-      set(DLLS_COPIED ON)
-    endif()    
+    endif()        
 endfunction()
 
 # ****************************************************************************

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,10 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/test_seed.hpp
 )
 
+if (WIN32)
+  set(DLLS_COPIED OFF)
+endif()
+
 function(add_rocthrust_test TEST)
     set(TEST_SOURCE "test_${TEST}.cpp")
     set(TEST_TARGET "${TEST}.hip")
@@ -41,12 +45,14 @@ function(add_rocthrust_test TEST)
             roc::rocprim_hip
             ${GTEST_BOTH_LIBRARIES}
     )
-    foreach(amdgpu_target ${AMDGPU_TARGETS})
-        target_link_libraries(${TEST_TARGET}
-            PRIVATE
-                --amdgpu-target=${amdgpu_target}
-        )
-    endforeach()
+    if (NOT WIN32)
+      foreach(amdgpu_target ${AMDGPU_TARGETS})
+          target_link_libraries(${TEST_TARGET}
+              PRIVATE
+                  --amdgpu-target=${amdgpu_target}
+          )
+      endforeach()
+    endif()
     set_target_properties(${TEST_TARGET}
         PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/"
@@ -67,6 +73,19 @@ function(add_rocthrust_test TEST)
                 LABELS "hip"
         )
     endif()
+    if (WIN32 AND NOT DLLS_COPIED)
+      # for now adding in all .dll as dependency chain is not cmake based on win32
+      file( GLOB third_party_dlls
+      LIST_DIRECTORIES ON
+      CONFIGURE_DEPENDS
+      ${HIP_DIR}/bin/*.dll
+      ${CMAKE_SOURCE_DIR}/rtest.*
+      )
+      foreach( file_i ${third_party_dlls})
+      add_custom_command( TARGET ${TEST_TARGET} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/test )
+      endforeach( file_i )
+      set(DLLS_COPIED ON)
+    endif()    
 endfunction()
 
 # ****************************************************************************

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,7 +72,6 @@ function(add_rocthrust_test TEST)
     if (WIN32 AND NOT DEFINED DLLS_COPIED)
       set(DLLS_COPIED "YES")
       set(DLLS_COPIED ${DLLS_COPIED} PARENT_SCOPE)
-      message(STATUS "copying dlls")
       # for now adding in all .dll as dependency chain is not cmake based on win32
       file( GLOB third_party_dlls
       LIST_DIRECTORIES ON

--- a/test/test_header.hpp
+++ b/test/test_header.hpp
@@ -79,7 +79,7 @@ struct Params
         using input_type = typename Params::input_type; \
     };                                                  \
                                                         \
-    TYPED_TEST_CASE(x, y);
+    TYPED_TEST_SUITE(x, y);
 
 // Set of test parameter types
 
@@ -182,6 +182,24 @@ typedef ::testing::Types<Params<short>,
 // Scalar signed interger types
 typedef ::testing::Types<Params<short>, Params<int>, Params<long long>> SignedIntegerTestsParams;
 
+#if defined(WIN32) && defined(__HIP__)
+// Scalar unsigned interger types of all lengths
+typedef ::testing::Types<Params<thrust::detail::uint16_t>,
+                         Params<thrust::detail::uint32_t>,
+                         Params<thrust::detail::uint64_t>>
+    UnsignedIntegerTestsParams;
+
+typedef ::testing::Types<Params<short>,
+                         Params<int>,
+                         Params<long long>,
+                         Params<unsigned short>,
+                         Params<unsigned int>,
+                         Params<unsigned long long>,
+                         Params<thrust::detail::uint16_t>,
+                         Params<thrust::detail::uint32_t>,
+                         Params<thrust::detail::uint64_t>>
+    AllIntegerTestsParams;
+#else
 // Scalar unsigned interger types of all lengths
 typedef ::testing::Types<Params<thrust::detail::uint8_t>,
                          Params<thrust::detail::uint16_t>,
@@ -201,6 +219,8 @@ typedef ::testing::Types<Params<short>,
                          Params<thrust::detail::uint32_t>,
                          Params<thrust::detail::uint64_t>>
     AllIntegerTestsParams;
+#endif
+
 
 // Scalar float types
 typedef ::testing::Types<Params<float>, Params<double>> FloatTestsParams;
@@ -223,7 +243,7 @@ struct ParamsInOut
         using output_type = typename ParamsInOut::output_type; \
     };                                                         \
                                                                \
-    TYPED_TEST_CASE(x, y);
+    TYPED_TEST_SUITE(x, y);
 
 typedef ::testing::Types<ParamsInOut<short>,
                          ParamsInOut<int>,

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -48,7 +48,7 @@ typedef ::testing::Types<ParamsSort<unsigned short, int, thrust::less<unsigned s
                          ParamsSort<int, long long>>
     SortTestsParams;
 
-TYPED_TEST_CASE(SortTests, SortTestsParams);
+TYPED_TEST_SUITE(SortTests, SortTestsParams);
 
 TESTS_DEFINE(SortVector, FullTestsParams);
 TESTS_DEFINE(SortVectorPrimitives, NumericalTestsParams);

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -191,6 +191,32 @@ inline auto get_random_data(size_t size, T min, T max, int seed) ->
     return data;
 }
 
+#if defined(WIN32) && defined(__clang__)
+template <>
+inline thrust::host_vector<unsigned char> get_random_data(size_t size, unsigned char min, unsigned char max, int seed_value)
+{
+    std::random_device                 rd;
+    std::default_random_engine         gen(rd());
+    gen.seed(seed_value);
+    std::uniform_int_distribution<int> distribution(static_cast<int>(min), static_cast<int>(max));
+    thrust::host_vector<unsigned char> data(size);
+    std::generate(data.begin(), data.end(), [&]() { return static_cast<unsigned char>(distribution(gen)); });
+    return data;
+}
+
+template <>
+inline thrust::host_vector<signed char> get_random_data(size_t size, signed char min, signed char max, int seed_value)
+{
+    std::random_device                 rd;
+    std::default_random_engine         gen(rd());
+    gen.seed(seed_value);
+    std::uniform_int_distribution<int> distribution(static_cast<int>(min), static_cast<int>(max));
+    thrust::host_vector<signed char> data(size);
+    std::generate(data.begin(), data.end(), [&]() { return static_cast<signed char>(distribution(gen)); });
+    return data;
+}
+#endif
+
 template <class T>
 struct custom_compare_less
 {

--- a/test/test_zip_iterator_sort_by_key.cpp
+++ b/test/test_zip_iterator_sort_by_key.cpp
@@ -20,7 +20,11 @@
 
 #include "test_header.hpp"
 
+#if defined(WIN32) && defined(__HIP__)
+typedef ::testing::Types<Params<int16_t>, Params<int32_t>> TestParams;
+#else
 typedef ::testing::Types<Params<int8_t>, Params<int16_t>, Params<int32_t>> TestParams;
+#endif
 
 TESTS_DEFINE(ZipIteratorStableSortByKeyTests, TestParams);
 

--- a/thrust/detail/complex/c99math.h
+++ b/thrust/detail/complex/c99math.h
@@ -173,9 +173,9 @@ __host__ __device__ inline float copysignf(float x, float y){
 
 
 #ifndef __CUDACC__
-
+#ifndef __HIP__
 // Simple approximation to log1p as Visual Studio is lacking one
-inline double log1p(double x){
+__host__ __device__ inline double log1p(double x){
   double u = 1.0+x;
   if(u == 1.0){
     return x;
@@ -189,7 +189,7 @@ inline double log1p(double x){
   }
 }
 
-inline float log1pf(float x){
+__host__ __device__ inline float log1pf(float x){
   float u = 1.0f+x;
   if(u == 1.0f){
     return x;
@@ -203,7 +203,9 @@ inline float log1pf(float x){
   }
 }
 
-#if _MSV_VER <= 1500
+#endif // __HIP__
+
+#if _MSC_VER <= 1500 && !defined(__clang__)
 #include <complex>
 
 inline float hypotf(float x, float y){

--- a/thrust/detail/complex/catrig.h
+++ b/thrust/detail/complex/catrig.h
@@ -589,7 +589,7 @@ inline double real_part_reciprocal(double x, double y)
  * Re(catanh(z)) = x/|z|^2 + O(x/z^4)
  *    as z -> infinity, uniformly in x
  */
-#if THRUST_CPP_DIALECT >= 2011 || THRUST_HOST_COMPILER != THRUST_HOST_COMPILER_MSVC
+#if (THRUST_CPP_DIALECT >= 2011 || THRUST_HOST_COMPILER != THRUST_HOST_COMPILER_MSVC) && !defined(__clang__)
 __host__ __device__ inline
 complex<double> catanh(complex<double> z)
 {
@@ -753,7 +753,7 @@ inline complex<double> asin(const complex<double>& z){
   return detail::complex::casin(z);
 }
 
-#if __cplusplus >= 201103L || !defined _MSC_VER
+#if( __cplusplus >= 201103L || !defined _MSC_VER) && !defined(__clang__)
 template <>
 __host__ __device__
 inline complex<double> atan(const complex<double>& z){
@@ -774,7 +774,7 @@ inline complex<double> asinh(const complex<double>& z){
   return detail::complex::casinh(z);
 }
 
-#if THRUST_CPP_DIALECT >= 2011 || THRUST_HOST_COMPILER != THRUST_HOST_COMPILER_MSVC
+#if (THRUST_CPP_DIALECT >= 2011 || THRUST_HOST_COMPILER != THRUST_HOST_COMPILER_MSVC) && !defined(__clang__)
 template <>
 __host__ __device__
 inline complex<double> atanh(const complex<double>& z){

--- a/thrust/detail/config/compiler.h
+++ b/thrust/detail/config/compiler.h
@@ -45,9 +45,14 @@
 
 // figure out which host compiler we're using
 #if defined(_MSC_VER)
-    #define THRUST_HOST_COMPILER THRUST_HOST_COMPILER_MSVC
-    #define THRUST_MSVC_VERSION _MSC_VER
-    #define THRUST_MSVC_VERSION_FULL _MSC_FULL_VER
+  #if defined(__clang__)
+    #define THRUST_HOST_COMPILER THRUST_HOST_COMPILER_CLANG
+    #define THRUST_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+  #else
+      #define THRUST_HOST_COMPILER THRUST_HOST_COMPILER_MSVC
+      #define THRUST_MSVC_VERSION _MSC_VER
+      #define THRUST_MSVC_VERSION_FULL _MSC_FULL_VER
+  #endif
 #elif defined(__clang__)
     #define THRUST_HOST_COMPILER THRUST_HOST_COMPILER_CLANG
     #define THRUST_CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)

--- a/thrust/detail/config/cpp_dialect.h
+++ b/thrust/detail/config/cpp_dialect.h
@@ -57,7 +57,7 @@
 
 // MSVC does not define __cplusplus correctly. _MSVC_LANG is used instead.
 // This macro is only defined in MSVC 2015U3+.
-#  ifdef _MSVC_LANG // Do not replace with THRUST_HOST_COMPILER test (see above)
+#if defined(_MSVC_LANG) && !defined(__HIP__) // Do not replace with THRUST_HOST_COMPILER test (see above)
 // MSVC2015 reports C++14 but lacks extended constexpr support. Treat as C++11.
 #    if THRUST_MSVC_VERSION < 1910 && _MSVC_LANG > 201103L /* MSVC < 2017 && CPP > 2011 */
 #      define THRUST_CPLUSPLUS 201103L /* Fix to 2011 */

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -1,0 +1,42 @@
+#set(CMAKE_MAKE_PROGRAM "nmake.exe")
+#set(CMAKE_GENERATOR "Ninja")
+# Ninja doesn't support platform
+#set(CMAKE_GENERATOR_PLATFORM x64)
+
+if (DEFINED ENV{ROCM_PATH})
+  set(rocm_bin "$ENV{ROCM_PATH}/hip/bin")
+else()
+  set(rocm_bin "/opt/rocm/hip/bin")
+endif()
+
+
+# set(CMAKE_CXX_COMPILER "hipcc")
+# set(CMAKE_C_COMPILER "hipcc")
+set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")
+set(CMAKE_C_COMPILER "${rocm_bin}/hipcc")
+
+#set(CMAKE_CXX_LINKER "hipcc" )
+
+# TODO remove, just to speed up slow cmake
+# set(CMAKE_C_COMPILER_WORKS 1)
+# set(CMAKE_CXX_COMPILER_WORKS 1)
+#
+
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
+
+# flags for clang direct use
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
+# -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
+
+# flags for clang direct use with hip
+# -x hip causes linker error
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+
+
+# set(GTEST_DIR "C:/rocm/Utils/GTestMSVC")
+# set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
+# set(GTEST_LIBRARY "${GTEST_DIR}/lib/Release/gtest.lib")
+# set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/lib/Release/gtest_main.lib")
+# set(GTEST_LIBRARIES "${GTEST_DIR}/lib/Release/gtest.lib;${GTEST_DIR}/lib/Release/gtest_main.lib")

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -1,0 +1,49 @@
+#set(CMAKE_MAKE_PROGRAM "nmake.exe")
+#set(CMAKE_GENERATOR "Ninja")
+# Ninja doesn't support platform
+#set(CMAKE_GENERATOR_PLATFORM x64)
+
+if (DEFINED ENV{HIP_DIR})
+  file(TO_CMAKE_PATH "$ENV{HIP_DIR}" HIP_DIR)
+  set(rocm_bin "${HIP_DIR}/bin")
+else()
+  set(HIP_DIR "C:/hip")
+  set(rocm_bin "C:/hip/bin")
+endif()
+
+#set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc.bat")
+#set(CMAKE_C_COMPILER "${rocm_bin}/hipcc.bat")
+set(CMAKE_CXX_COMPILER "${rocm_bin}/clang++.exe")
+set(CMAKE_C_COMPILER "${rocm_bin}/clang.exe")
+
+#set(CMAKE_CXX_LINKER "${rocm_bin}/hipcc.bat" )
+
+# TODO remove, just to speed up slow cmake
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+#
+
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
+
+# flags for clang direct use
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
+# -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
+
+# flags for clang direct use with hip
+# -x hip causes linker error
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HIP_DIR}/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+
+if (DEFINED ENV{VCPKG_PATH})
+  file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)
+else()
+  set(VCPKG_PATH "C:/github/vcpkg")
+endif()
+include("${VCPKG_PATH}/scripts/buildsystems/vcpkg.cmake")
+# set(GTEST_DIR "C:/rocm/Utils/GTestMSVC")
+# set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
+# set(GTEST_LIBRARY "${GTEST_DIR}/lib/Release/gtest.lib")
+# set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/lib/Release/gtest_main.lib")
+# set(GTEST_LIBRARIES "${GTEST_DIR}/lib/Release/gtest.lib;${GTEST_DIR}/lib/Release/gtest_main.lib")


### PR DESCRIPTION
Initial HIP on Windows support for rocThrust. Currently on my test machine rocThrust builds and installs.  Three unit tests are failing:  async_copy.hip, partition.hip, stable_sort_by_key_large.hip.  I am disabling them in rtest.xml for now.  Root cause of failures are still being investigated.

How to build with HIP on Windows:

Get system dependencies with rdeps.py: python rdeps.py
Install using new rmake.py script: python rmake.py
To run tests: python rtest.py -t <insert test set name here, see rtest.xml for test set names>

I have not tested rmake.py with linux yet, I suspect it still needs some work, but the currently install.sh script works just as it did before for linux. Long-term we can decide what we want to do with install.sh/rmake.py.