### PR TITLE
Adding option to force install GTest. 

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -19,7 +19,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 cd ${project.paths.project_build_prefix}
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${amdgpuTargets} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../..
+                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${amdgpuTargets} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ../..
                 make -j\$(nproc)
                 """
 

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -4,7 +4,7 @@
 def runCompileCommand(platform, project, jobName, boolean debug=false, boolean sameOrg=true)
 {
     project.paths.construct_build_prefix()
-        
+
     String buildTypeArg = debug ? '-DCMAKE_BUILD_TYPE=Debug' : '-DCMAKE_BUILD_TYPE=Release'
     String buildTypeDir = debug ? 'debug' : 'release'
     String cmake = platform.jenkinsLabel.contains('centos') ? 'cmake3' : 'cmake'
@@ -19,10 +19,10 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 cd ${project.paths.project_build_prefix}
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 ${auxiliary.gfxTargetParser()}
-                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${amdgpuTargets} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON ../..
+                ${cmake} -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc ${buildTypeArg} ${amdgpuTargets} -DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DDEPENDENCIES_FORCE_DOWNLOAD=ON ../..
                 make -j\$(nproc)
                 """
-    
+
     platform.runCommand(this, command)
 }
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -42,7 +42,12 @@ endif()
 
 # Test dependencies
 if(BUILD_TEST)
-  find_package(GTest QUIET)
+  if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
+    # Google Test (https://github.com/google/googletest)
+    find_package(GTest QUIET)
+  else()
+    message(STATUS "Force installing GTest.")
+  endif()
 
   if(NOT TARGET GTest::GTest AND NOT TARGET GTest::gtest)
     message(STATUS "GTest not found or force download GTest on. Downloading and building GTest.")

--- a/test/test_device_delete.cpp
+++ b/test/test_device_delete.cpp
@@ -42,10 +42,12 @@ struct Foo
 };
 
 // KNOWN_FAILURE
-/*TEST(DeviceDelete, TestDeviceDeleteDestructorInvocation)
+// GTest may throw a link error if there is not at least 1 test case per executable
+TEST(DeviceDelete, TestDeviceDeleteDestructorInvocation)
 {
+    /*
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
-    
+
     thrust::device_vector<bool> destructor_flag(1, false);
 
     thrust::device_ptr<Foo> foo_ptr = thrust::device_new<Foo>();
@@ -58,5 +60,5 @@ struct Foo
 
     thrust::device_delete(foo_ptr);
 
-    ASSERT_EQ(true, destructor_flag[0]);
-}*/
+    ASSERT_EQ(true, destructor_flag[0]);*/
+}


### PR DESCRIPTION
Also making it force install GTest 1.10 by default on jenkins CI.  Looks like we're grabbing an older version of Gtest there, causing CI failures.