### PR TITLE
cmake fix for HIP on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,12 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker searc
 
 # rocm-cmake contains common cmake code for rocm projects to help
 # setup and install
-find_package(ROCM 0.6 REQUIRED CONFIG PATHS /opt/rocm)
+if(WIN32)
+  find_package(ROCM CONFIG QUIET PATHS ${ROCM_PATH} /opt/rocm)
+  include (cmake/HIPOnWindowsDependencies.cmake)
+else()
+  find_package(ROCM 0.6 REQUIRED CONFIG PATHS /opt/rocm)
+endif()
 include( ROCMSetupVersion )
 include( ROCMCreatePackage )
 include( ROCMInstallTargets )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker searc
 # rocm-cmake contains common cmake code for rocm projects to help
 # setup and install
 if(WIN32)
-  find_package(ROCM CONFIG QUIET PATHS ${ROCM_PATH} /opt/rocm)
   include (cmake/HIPOnWindowsDependencies.cmake)
 else()
   find_package(ROCM 0.6 REQUIRED CONFIG PATHS /opt/rocm)

--- a/cmake/HIPOnWindowsDependencies.cmake
+++ b/cmake/HIPOnWindowsDependencies.cmake
@@ -1,0 +1,36 @@
+# ########################################################################
+# Copyright 2021 Advanced Micro Devices, Inc.
+# ########################################################################
+
+# ###########################
+# rocThrust dependencies
+# ###########################
+
+if (WIN32)
+  if(NOT ROCM_FOUND)
+    set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
+    file(
+      DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
+      ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+      STATUS rocm_cmake_download_status LOG rocm_cmake_download_log
+    )
+    list(GET rocm_cmake_download_status 0 rocm_cmake_download_error_code)
+    if(rocm_cmake_download_error_code)
+      message(FATAL_ERROR "Error: downloading "
+        "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip failed "
+        "error_code: ${rocm_cmake_download_error_code} "
+        "log: ${rocm_cmake_download_log} "
+      )
+    endif()
+
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      RESULT_VARIABLE rocm_cmake_unpack_error_code
+    )
+    if(rocm_cmake_unpack_error_code)
+      message(FATAL_ERROR "Error: unpacking  ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
+    endif()
+    find_package(ROCM REQUIRED CONFIG PATHS ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag})
+  endif()
+endif()

--- a/cmake/HIPOnWindowsDependencies.cmake
+++ b/cmake/HIPOnWindowsDependencies.cmake
@@ -7,6 +7,7 @@
 # ###########################
 
 if (WIN32)
+  find_package(ROCM CONFIG QUIET PATHS ${ROCM_PATH} /opt/rocm)
   if(NOT ROCM_FOUND)
     set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
     file(

--- a/cmake/HIPOnWindowsDependencies.cmake
+++ b/cmake/HIPOnWindowsDependencies.cmake
@@ -7,7 +7,7 @@
 # ###########################
 
 if (WIN32)
-  find_package(ROCM CONFIG QUIET PATHS ${ROCM_PATH} /opt/rocm)
+  find_package(ROCM 0.6 CONFIG QUIET PATHS ${ROCM_PATH})
   if(NOT ROCM_FOUND)
     set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
     file(


### PR DESCRIPTION
rocThrust now builds with HIP on Windows again, but still preserving the required order for Linux.