### PR TITLE
Update macro for AMD platform check

### DIFF
--- a/thrust/system/hip/detail/guarded_driver_types.h
+++ b/thrust/system/hip/detail/guarded_driver_types.h
@@ -37,7 +37,7 @@
 #    define THRUST_DEVICE_NEEDS_RESTORATION
 #  endif
 #else // GNUC pre 4.5.0
-#  if !defined(HIP_INCLUDE_HIP_AMD_DETAIL_DRIVER_TYPES_H)
+#  if !defined(__HIP_PLATFORM_AMD__)
 #    ifdef __host__
 #      undef __host__
 #    endif


### PR DESCRIPTION
In newer HIP builds, the old macro generates build errors.  Update macro to __HIP_PLATFORM_AMD__ fixes the problem.