### PR TITLE
Revert install location to thrust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,15 +174,13 @@ endif()
 #Create header wrapper for backward compatibility
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
   rocm_wrap_header_dir(
-            ${CMAKE_SOURCE_DIR}/thrust
-	    PATTERNS "*.h"
-	    PATTERNS "*.inl"
-	    PATTERN "*.cuh"
-	    PATTERN "*.hpp"
+      ${CMAKE_SOURCE_DIR}/thrust
+	    PATTERNS "*.h" "*.inl" "*.cuh" "*.hpp"
+      HEADER_LOCATION include/thrust
 	    GUARDS SYMLINK WRAPPER
 	    WRAPPER_LOCATIONS rocthrust/include/thrust
-            OUTPUT_LOCATIONS rocthrust/wrapper/include/thrust
-	  )
+      OUTPUT_LOCATIONS rocthrust/wrapper/include/thrust
+  )
 endif( )
 
 set(THRUST_OPTIONS_DEBUG ${THRUST_OPTIONS_WARNINGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,10 +175,10 @@ endif()
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
   rocm_wrap_header_dir(
       ${CMAKE_SOURCE_DIR}/thrust
-	    PATTERNS "*.h" "*.inl" "*.cuh" "*.hpp"
+      PATTERNS "*.h" "*.inl" "*.cuh" "*.hpp"
       HEADER_LOCATION include/thrust
-	    GUARDS SYMLINK WRAPPER
-	    WRAPPER_LOCATIONS rocthrust/include/thrust
+      GUARDS SYMLINK WRAPPER
+      WRAPPER_LOCATIONS rocthrust/include/thrust
       OUTPUT_LOCATIONS rocthrust/wrapper/include/thrust
   )
 endif( )

--- a/thrust/CMakeLists.txt
+++ b/thrust/CMakeLists.txt
@@ -15,6 +15,7 @@ configure_file(
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
   rocm_wrap_header_file(
       "rocthrust_version.hpp"
+      HEADER_LOCATION include/thrust
       WRAPPER_LOCATIONS rocthrust/include/thrust
       OUTPUT_LOCATIONS rocthrust/wrapper/include/thrust
   )
@@ -54,7 +55,7 @@ rocm_install(
   DIRECTORY
     "./"
     "${PROJECT_BINARY_DIR}/thrust/include/"
-  DESTINATION include/rocthrust
+  DESTINATION include/thrust
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "*.cuh"


### PR DESCRIPTION
#224 incorrectly changed the header install location to `/opt/rocm/include/rocthrust/...`. This PR moves it to `/opt/rocm/include/thrust`, including wrappers in the old location `/opt/rocm/rocthrust/include/thrust`.