### PR TITLE
Hotfixes from release/rocm-rel-5.2 at release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocThrust is available at [https://rocthrust.readthedocs.io/en/latest/](https://rocthrust.readthedocs.io/en/latest/)
 
-## (Unreleased) rocThrust 2.15.0 for ROCm 5.2
+## rocThrust 2.15.0 for ROCm 5.2
 ### Added
 - Packages for tests and benchmark executable on all supported OSes using CPack.
 


### PR DESCRIPTION
This is an autogenerated PR.
 This is intended to pull any hotfixes for ROCm release 5.2.0 (including changelogs and documentation) back into develop.