### PR TITLE
Remove Git from build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Thrust is a parallel algorithm library. This library has been ported to [HIP](ht
 
 ### Software
 
-* Git
 * CMake (3.5.1 or later)
 * AMD [ROCm](https://rocm.github.io/install.html) platform (1.8.0 or later)
   * Including [HipCC](https://github.com/ROCm-Developer-Tools/HIP) compiler, which must be

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -12,12 +12,6 @@
 # For downloading, building, and installing required dependencies
 include(cmake/DownloadProject.cmake)
 
-# GIT
-find_package(Git REQUIRED)
-if (NOT Git_FOUND)
-  message(FATAL_ERROR "Please ensure Git is installed on the system")
-endif()
-
 # rocPRIM (https://github.com/ROCmSoftwarePlatform/rocPRIM)
 if(NOT DOWNLOAD_ROCPRIM)
   find_package(rocprim QUIET)


### PR DESCRIPTION
The `find_package(Git REQUIRED)` doesn't seem to be used. There are some calls to `ExternalProject_Add` depending on the options (and they might require git), but they don't require this `find_package`.