### PR TITLE
Fix binary search operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Full documentation for rocThrust is available at [https://rocthrust.readthedocs.
 - Updated to match upstream Thrust 1.17.2
 ### Fixed
 - set_difference and set_intersection no longer hang if the number of items is above `UINT_MAX`. Previously, the unit tests for set_difference and set_intersection failed the `TestSetDifferenceWithBigIndexes`.
+- `lower_bound`, `upper_bound`, and `binary_search` failed to compile for certain types.
 
 ## rocThrust 2.16.0 for ROCm 5.3
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 Full documentation for rocThrust is available at [https://rocthrust.readthedocs.io/en/latest/](https://rocthrust.readthedocs.io/en/latest/)
 
+## (Unreleased) rocThrust 2.18.0 for ROCm 6.0
+### Fixed 
+- `lower_bound`, `upper_bound`, and `binary_search` failed to compile for certain types.
+
 ## (Unreleased) rocThrust 2.17.0 for ROCm 5.5
 ### Added
 - Updated to match upstream Thrust 1.17.2
 ### Fixed
 - set_difference and set_intersection no longer hang if the number of items is above `UINT_MAX`. Previously, the unit tests for set_difference and set_intersection failed the `TestSetDifferenceWithBigIndexes`.
-- `lower_bound`, `upper_bound`, and `binary_search` failed to compile for certain types.
 
 ## rocThrust 2.16.0 for ROCm 5.3
 ### Added

--- a/thrust/system/hip/detail/binary_search.h
+++ b/thrust/system/hip/detail/binary_search.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2022, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -64,6 +64,8 @@ namespace __binary_search
         hipStream_t stream       = hip_rocprim::stream(policy);
         bool        debug_sync   = THRUST_HIP_DEBUG_SYNC_FLAG;
 
+        thrust::detail::wrapped_function<CompareOp, bool> wrapped_op(compare_op);
+
         // Determine temporary device storage requirements.
         hip_rocprim::throw_on_error(rocprim::lower_bound(NULL,
                                                          storage_size,
@@ -72,7 +74,7 @@ namespace __binary_search
                                                          result,
                                                          haystack_size,
                                                          needles_size,
-                                                         compare_op,
+                                                         wrapped_op,
                                                          stream,
                                                          debug_sync),
                                     "lower_bound: failed on 1st call");
@@ -89,7 +91,7 @@ namespace __binary_search
                                                          result,
                                                          haystack_size,
                                                          needles_size,
-                                                         compare_op,
+                                                         wrapped_op,
                                                          stream,
                                                          debug_sync),
                                     "lower_bound: failed on 2nt call");
@@ -124,6 +126,8 @@ namespace __binary_search
         hipStream_t stream       = hip_rocprim::stream(policy);
         bool        debug_sync   = THRUST_HIP_DEBUG_SYNC_FLAG;
 
+        thrust::detail::wrapped_function<CompareOp, bool> wrapped_op(compare_op);
+
         // Determine temporary device storage requirements.
         hip_rocprim::throw_on_error(rocprim::upper_bound(NULL,
                                                          storage_size,
@@ -132,7 +136,7 @@ namespace __binary_search
                                                          result,
                                                          haystack_size,
                                                          needles_size,
-                                                         compare_op,
+                                                         wrapped_op,
                                                          stream,
                                                          debug_sync),
                                     "upper_bound: failed on 1st call");
@@ -149,7 +153,7 @@ namespace __binary_search
                                                          result,
                                                          haystack_size,
                                                          needles_size,
-                                                         compare_op,
+                                                         wrapped_op,
                                                          stream,
                                                          debug_sync),
                                     "upper_bound: failed on 2nt call");
@@ -184,6 +188,8 @@ namespace __binary_search
         hipStream_t stream       = hip_rocprim::stream(policy);
         bool        debug_sync   = THRUST_HIP_DEBUG_SYNC_FLAG;
 
+        thrust::detail::wrapped_function<CompareOp, bool> wrapped_op(compare_op);
+
         // Determine temporary device storage requirements.
         hip_rocprim::throw_on_error(rocprim::binary_search(NULL,
                                                            storage_size,
@@ -192,7 +198,7 @@ namespace __binary_search
                                                            result,
                                                            haystack_size,
                                                            needles_size,
-                                                           compare_op,
+                                                           wrapped_op,
                                                            stream,
                                                            debug_sync),
                                     "binary_search: failed on 1st call");
@@ -209,7 +215,7 @@ namespace __binary_search
                                                            result,
                                                            haystack_size,
                                                            needles_size,
-                                                           compare_op,
+                                                           wrapped_op,
                                                            stream,
                                                            debug_sync),
                                     "binary_search: failed on 2nt call");


### PR DESCRIPTION
For binary search, the operator that rocThrust passes to the rocPRIM backend gives a compile error when using a non-`device_reference` value with a `device_reference` from the array. This happens for data types that cannot be implicitly converted from a `device_reference`, such as `thrust::tuple`. This is fixed by wrapping the operator in a functor that does this conversion explicitly. The tests for this algorithm are extended to include the described behavior.