### PR TITLE
Fix warnings during compilation

### DIFF
--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -78,7 +78,7 @@ function(add_rocthrust_test TEST_NAME TEST_SOURCES)
     foreach(amdgpu_target ${AMDGPU_TARGETS})
       target_link_libraries(${TEST_TARGET}
         PRIVATE
-          --amdgpu-target=${amdgpu_target}
+          --offload-arch=${amdgpu_target}
       )
   endif()
   endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,7 +66,7 @@ function(add_rocthrust_test TEST)
       foreach(amdgpu_target ${AMDGPU_TARGETS})
           target_link_libraries(${TEST_TARGET}
               PRIVATE
-                  --amdgpu-target=${amdgpu_target}
+                  --offload-arch=${amdgpu_target}
           )
       endforeach()
     endif()

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -144,11 +144,11 @@ template<typename T> struct has_trivial_constructor
       is_pod<T>::value
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __has_trivial_constructor(T)
+      || __is_trivially_constructible(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __has_trivial_constructor(T)
+      || __is_trivially_constructible(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER
       >

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -144,11 +144,11 @@ template<typename T> struct has_trivial_constructor
       is_pod<T>::value
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __is_trivially_copyable(T)
+      || __is_trivially_constructible(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __is_trivially_copyable(T)
+      || __is_trivially_constructible(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER
       >

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -144,11 +144,11 @@ template<typename T> struct has_trivial_constructor
       is_pod<T>::value
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __is_trivially_constructible(T)
+      || __is_trivially_copyable(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __is_trivially_constructible(T)
+      || __is_trivially_copyable(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER
       >
@@ -160,11 +160,11 @@ template<typename T> struct has_trivial_copy_constructor
       is_pod<T>::value
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __is_trivially_constructible(T)
+      || __is_trivially_copyable(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __is_trivially_constructible(T)
+      || __is_trivially_copyable(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER
     >

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -160,11 +160,11 @@ template<typename T> struct has_trivial_copy_constructor
       is_pod<T>::value
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __has_trivial_copy(T)
+      || __is_trivially_constructible(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __has_trivial_copy(T)
+      || __is_trivially_constructible(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER
     >

--- a/thrust/detail/type_traits/has_trivial_assign.h
+++ b/thrust/detail/type_traits/has_trivial_assign.h
@@ -35,14 +35,14 @@ template<typename T> struct has_trivial_assign
       bool,
       (is_pod<T>::value && !is_const<T>::value)
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
-      || __has_trivial_assign(T)
+      || __is_trivially_assignable(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __has_trivial_assign(T)
+      || __is_trivially_assignable(T)
 #endif // GCC VERSION
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __has_trivial_assign(T)
+      || __is_trivially_assignable(T)
 #endif // THRUST_HOST_COMPILER
     >
 {};

--- a/thrust/detail/type_traits/has_trivial_assign.h
+++ b/thrust/detail/type_traits/has_trivial_assign.h
@@ -35,14 +35,14 @@ template<typename T> struct has_trivial_assign
       bool,
       (is_pod<T>::value && !is_const<T>::value)
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
-      || __is_trivially_assignable(T)
+      || __is_trivially_assignable(T, const T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __is_trivially_assignable(T)
+      || __is_trivially_assignable(T, const T)
 #endif // GCC VERSION
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __is_trivially_assignable(T)
+      || __is_trivially_assignable(T, const T)
 #endif // THRUST_HOST_COMPILER
     >
 {};


### PR DESCRIPTION
With newer compiler versions and certain OSes, we get a lot of warnings during compilation, specifically with __has_trivial_constructor and amdgpu-target.  