### PR TITLE
Fix changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocThrust is available at [https://rocthrust.readthedocs.io/en/latest/](https://rocthrust.readthedocs.io/en/latest/)
 
-## (Unreleased) rocThrust 2.18.0 for ROCm 6.0
+## (Unreleased) rocThrust 2.18.0 for ROCm 5.6
 ### Fixed 
 - `lower_bound`, `upper_bound`, and `binary_search` failed to compile for certain types.
 


### PR DESCRIPTION
Previous changelog entry was made before the decision to have ROCm 5.6.