### PR TITLE
Develop stream 2023 05 18

### DIFF
--- a/.githooks/install
+++ b/.githooks/install
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd "$(git rev-parse --git-dir)"
+cd hooks
+
+echo "Installing hooks..." 
+ln -s ../../.githooks/pre-commit pre-commit
+echo "Done!"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Redirect output to stderr.
+exec 1>&2
+
+check_failed=false
+
+# Do the copyright check
+# update & apply copyright when hook config is set, otherwise just verify
+opts="-qc"
+if [ "$(git config --get --type bool --default false hooks.updateCopyright)" = "true" ]; then
+    opts="-qca"
+fi
+
+if ! "$(git rev-parse --show-toplevel)/scripts/copyright-date/check-copyright.sh" "$opts" 1>&2; then
+    printf "\n\033[31mFailed\033[0m: copyright date check.\n"
+    check_failed=true
+fi
+
+if $check_failed; then
+    printf "
+Pre-commit check failed, please fix the reported errors.
+Note: Use '\033[33mgit commit --no-verify\033[0m' to bypass checks.\n"
+    exit 1
+fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,10 @@ test:
       -D CMAKE_PREFIX_PATH=/opt/rocm
       -P $CI_PROJECT_DIR/cmake/GenerateResourceSpec.cmake
     - cat ./resources.json
-    - ctest
+    # Parallel execution (with other AMDGPU processes) can oversubscribe the SDMA queue.
+    # This causes the hipMemcpy to fail, which is not reported as an error by HIP.
+    # As a temporary workaround, disable the SDMA for test stability.
+    - HSA_ENABLE_SDMA=0 ctest
       --output-on-failure
       --repeat-until-fail 2
       --tests-regex $GPU_TARGET

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2019-2022 Advanced Micro Devices, Inc.
+# Copyright 2019-2023 Advanced Micro Devices, Inc.
 # ########################################################################
 
 include:
@@ -14,6 +14,7 @@ include:
       - /rules.yaml
 
 stages:
+  - lint
   - build   # Tests if builds succeed (CMake)
   - test    # Tests if unit tests are passing (CTest)
 
@@ -21,6 +22,20 @@ variables:
   # Helper variables
   PACKAGE_DIR: $BUILD_DIR/package
   ROCPRIM_GIT_BRANCH: develop_stream
+
+copyright-date:
+  extends:
+    - .deps:rocm
+  stage: lint
+  needs: []
+  tags:
+    - rocm-build
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+  script:
+    - cd $CI_PROJECT_DIR
+    - git config --global --add safe.directory $CI_PROJECT_DIR
+    - scripts/copyright-date/check-copyright.sh -v -d $CI_MERGE_REQUEST_DIFF_BASE_SHA
 
 .cmake-latest:
   extends:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocThrust is available at [https://rocthrust.readthedocs.io/en/latest/](https://rocthrust.readthedocs.io/en/latest/)
 
-## (Unreleased) rocThrust 2.18.0 for ROCm 5.6
+## (Unreleased) rocThrust 2.18.0 for ROCm 5.7
 ### Fixed 
 - `lower_bound`, `upper_bound`, and `binary_search` failed to compile for certain types.
 - Fixed issue where `transform_iterator` would not compile with `__device__`-only operators.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ Full documentation for rocThrust is available at [https://rocthrust.readthedocs.
 ## (Unreleased) rocThrust 2.18.0 for ROCm 5.6
 ### Fixed 
 - `lower_bound`, `upper_bound`, and `binary_search` failed to compile for certain types.
+- Fixed issue where `transform_iterator` would not compile with `__device__`-only operators.
 ### Changed
 - Updated `docs` directory structure to match the standard of [rocm-docs-core](https://github.com/RadeonOpenCompute/rocm-docs-core).
 
-## (Unreleased) rocThrust 2.17.0 for ROCm 5.5
+## rocThrust 2.17.0 for ROCm 5.5
 ### Added
 - Updated to match upstream Thrust 1.17.2
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for rocThrust is available at [https://rocthrust.readthedocs.
 - Fixed issue where `transform_iterator` would not compile with `__device__`-only operators.
 ### Changed
 - Updated `docs` directory structure to match the standard of [rocm-docs-core](https://github.com/RadeonOpenCompute/rocm-docs-core).
+- Removed references to and workarounds for deprecated hcc
 
 ## rocThrust 2.17.0 for ROCm 5.5
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2019-2020 Advanced Micro Devices, Inc.
+# Copyright 2019-2023 Advanced Micro Devices, Inc.
 # ########################################################################
 
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
@@ -74,7 +74,7 @@ set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific ma
 # Get dependencies
 include(cmake/Dependencies.cmake)
 
-# Verify that hcc or hipcc compiler is used on ROCM platform
+# Verify that supported compilers are used
 if (NOT WIN32)
   include(cmake/VerifyCompiler.cmake)
 endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2019 Advanced Micro Devices, Inc.
+# Copyright 2019-2023 Advanced Micro Devices, Inc.
 # ########################################################################
 
 # ###########################
@@ -60,7 +60,6 @@ if(BUILD_TEST)
       BUILD_PROJECT       TRUE
       UPDATE_DISCONNECTED TRUE
     )
-    list( APPEND CMAKE_PREFIX_PATH ${GTEST_ROOT} )
-    find_package(GTest REQUIRED)
+    find_package(GTest REQUIRED CONFIG PATHS ${GTEST_ROOT})
   endif()
 endif()

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ function (print_configuration_summary)
     message(STATUS "  CXX flags             : ${CMAKE_CXX_FLAGS_STRIP}")
     message(STATUS "  Build type            : ${CMAKE_BUILD_TYPE}")
     message(STATUS "  Install prefix        : ${CMAKE_INSTALL_PREFIX}")
-if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
+if(HIP_COMPILER STREQUAL "clang")
     message(STATUS "  Device targets        : ${AMDGPU_TARGETS}")
 endif()
     message(STATUS "")

--- a/cmake/VerifyCompiler.cmake
+++ b/cmake/VerifyCompiler.cmake
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,18 +25,10 @@ find_package(hip REQUIRED CONFIG PATHS /opt/rocm)
 
 if(HIP_COMPILER STREQUAL "nvcc")
     message(FATAL_ERROR "rocThrust does not support the CUDA backend.")
-elseif(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
-    if(NOT (CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hipcc$"))
-        message(FATAL_ERROR "On ROCm platform 'hcc' or 'clang' must be used as C++ compiler.")
-    elseif(NOT CXX_VERSION_STRING MATCHES "clang")
-        list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
-    endif()
-
-    if(HIP_COMPILER STREQUAL "hcc")
-      list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc)
-      find_package(hcc REQUIRED CONFIG PATHS /opt/rocm)
+elseif(HIP_COMPILER STREQUAL "clang")
+    if(NOT (CMAKE_CXX_COMPILER MATCHES ".*hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*clang\\+\\+"))
+        message(FATAL_ERROR "On ROCm platform 'hipcc' or HIP-aware Clang must be used as C++ compiler.")
     endif()
 else()
-    message(FATAL_ERROR "HIP_COMPILER must be 'hcc' or 'clang' (AMD ROCm platform)")
+    message(FATAL_ERROR "HIP_COMPILER must be `clang` (AMD ROCm platform)")
 endif()

--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2019 Advanced Micro Devices, Inc.
+# Copyright 2019-2023 Advanced Micro Devices, Inc.
 # ########################################################################
 
 cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
@@ -31,7 +31,7 @@ else()
   set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
 endif()
 
-# Verify that hcc or hipcc compiler is used on ROCM platform
+# Verify that supported compilers are used
 include(VerifyCompiler)
 include(DownloadProject)
 

--- a/install
+++ b/install
@@ -112,10 +112,6 @@ if [[ "${build_relocatable}" == true ]]; then
     fi
 fi
 
-# Instal the pre-commit hook
-#bash .githooks/install
-
-
 # Create and go to the build directory.
 mkdir -p build; cd build
 
@@ -126,14 +122,7 @@ else
 fi
 
 # Configure rocThrust, setup options for your system.
-# Build options:
-#   BUILD_TEST - off by default,
-#   BUILD_BENCHMARK - off by default.
-#
-# ! IMPORTANT !
-# On ROCm platform set C++ compiler to HIPCC. You can do it by adding 'CXX=<path-to-hcc>'
-# before 'cmake' or setting cmake option 'CMAKE_CXX_COMPILER' to path to the HIPCC compiler.
-#
+# See README.md under "Build And Install" for options and defaults.
 
 # Set compiler
 compiler="hipcc"
@@ -174,8 +163,8 @@ make -j$(nproc)
 check_exit_code "$?"
 
 if ($run_tests); then
-# Optionally, run tests if they're enabled.
-ctest --output-on-failure
+    # Optionally, run tests if they're enabled.
+    ctest --output-on-failure
 fi
 
 if ($install_package); then

--- a/internal/benchmark/timer.h
+++ b/internal/benchmark/timer.h
@@ -121,7 +121,7 @@ class cuda_timer
 
 #endif
 
-#if (THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || defined(WIN32))
+#if(THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || defined(_WIN32))
 #include <windows.h>
 
 class steady_timer

--- a/scripts/copyright-date/check-copyright.sh
+++ b/scripts/copyright-date/check-copyright.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+# Start of configuration
+preamble="Copyright +(\([cC]\) +)?"
+postamble=",? +Advanced +Micro +Devices, +Inc\."
+find_pattern="$preamble([0-9]{4}-)?[0-9]{4}$postamble"
+# printf format string, receives the current year as a parameter
+uptodate_pattern="$preamble([0-9]{4}-)?%d$postamble"
+# <pattern>/<replacement> interpreted with sed syntax, also passed to printf
+# printf interprets '\' escape sequences so they must be escaped
+# The capture groups are as follows:
+#   - \1 is the whole preamble text
+#   - \3 is the start year, \2 is skipped because it is used for an optional part of the preamble
+#   - \5 is the end of the copyright statement after the end year, \4 would be the original end year
+#     as written in the file, it is replaced by the current year instead.
+replace_pattern="($preamble)([0-9]{4})(-[0-9]{4})?($postamble)/\\\1\\\3-%d\\\5"
+# End of configuration
+
+print_help() { printf -- \
+"\033[36musuage\033[0m: \033[33mcheck_year.sh [-h] [-u] [-a] [-d <SHA>] [-k] [-v]\033[0m
+\033[36mdescription\033[0m: Checks for if the copyright year in the staged files is up to date and displays the files with out-of-date copyright statements. Exits with '0' if successful and with '1' if something is out of date.
+\033[36moptions\033[0m:
+  \033[34m-h\033[0m       Displays this message.
+  \033[34m-u\033[0m       Automatically updates the copyright year
+  \033[34m-a\033[0m       Automatically applies applies the changes to current staging environment. Implies '-u' and '-c'.
+  \033[34m-c\033[0m       Compare files to the index instead of the working tree.
+  \033[34m-d <SHA>\033[0m Compare using the diff of a hash.
+  \033[34m-k\033[0m       Compare using the fork point: where this branch and 'remotes/origin/HEAD' diverge.
+  \033[34m-q\033[0m       Suppress updates about progress.
+  \033[34m-v\033[0m       Verbose output.
+Use '\033[33mgit config --local hooks.updateCopyright <true|false>\033[0m' to automatically apply copyright changes on commit.
+"
+}
+
+# argument parsing
+apply=false
+update=false
+verbose=false
+forkdiff=false
+quiet=false
+cached=false
+
+while getopts "auhvkqcd:" arg; do
+    case $arg in
+        a) update=true;apply=true;cached=true;;
+        u) update=true;;
+        v) verbose=true;;
+        k) forkdiff=true;;
+        q) quiet=true;;
+        c) cached=true;;
+        d) diff_hash=${OPTARG};;
+        h) print_help; exit;;
+        *) print help; exit 1;;
+    esac
+done
+
+# If set, check all files changed since the fork point
+if $forkdiff; then
+    branch="$(git rev-parse --abbrev-ref HEAD)"
+    remote="$(git config --local --get "branch.$branch.remote" || echo 'origin')"
+    source_commit="remotes/$remote/HEAD"
+
+    # don't use fork-point for finding fork point (lol)
+    # see: https://stackoverflow.com/a/53981615
+    diff_hash="$(git merge-base "$source_commit" "$branch")"
+fi
+
+if [ -n "${diff_hash}" ]; then
+    $verbose && printf -- "Using base commit: %s\n" "${diff_hash}"
+else
+    diff_hash="HEAD"
+fi
+
+# Current year
+year="$(date +%Y)"
+
+# Enable rename detection with full matches only, this skips copyright checks for file name only
+# changes.
+diff_opts=(-z --name-only '--diff-filter=MA' '--find-renames=100%')
+git_grep_opts=(-z --extended-regexp --ignore-case --no-recursive -I)
+if $cached; then
+    diff_opts+=(--cached)
+    git_grep_opts+=(--cached)
+fi
+
+! $quiet && printf -- "Checking if copyright statements are up-to-date... "
+mapfile -d $'\0' changed_files < <(git diff-index "${diff_opts[@]}" "$diff_hash" | LANG=C.UTF-8 sort -z)
+
+if ! (( ${#changed_files[@]} )); then
+    ! $quiet && printf -- "\033[32mDone!\033[0m\n"
+    $verbose && printf -- "\033[36mNo changed files found.\033[0m\n"
+    exit 0
+fi;
+
+mapfile -d $'\0' found_copyright < <(                                      \
+    git grep "${git_grep_opts[@]}" --files-with-matches -e "$find_pattern" \
+        -- "${changed_files[@]}" |                                         \
+    LANG=C.UTF-8 sort -z)
+
+outdated_copyright=()
+if (( ${#found_copyright[@]} )); then
+    # uptodate_pattern variable holds the format string using it as such is intentional
+    # shellcheck disable=SC2059
+    printf -v uptodate_pattern -- "$uptodate_pattern" "$year"
+    mapfile -d $'\0' outdated_copyright < <(                                        \
+        git grep "${git_grep_opts[@]}" --files-without-match -e "$uptodate_pattern" \
+            -- "${found_copyright[@]}" |                                            \
+        LANG=C.UTF-8 sort -z)
+fi
+
+! $quiet && printf -- "\033[32mDone!\033[0m\n"
+if $verbose; then
+    # Compute the files that don't have a copyright as the set difference of
+    # `changed_files and `found_copyright`
+    mapfile -d $'\0' notfound_copyright < <(                                   \
+        printf -- '%s\0' "${changed_files[@]}" |                               \
+        LANG=C.UTF-8 comm -z -23 - <(printf -- '%s\0' "${found_copyright[@]}"))
+
+    if (( ${#notfound_copyright[@]} )); then
+        printf -- "\033[36mCouldn't find a copyright statement in %d file(s):\033[0m\n" \
+            "${#notfound_copyright[@]}"
+        printf -- '  - %q\n' "${notfound_copyright[@]}"
+    fi
+
+    # Similarly the up-to-date files are the difference of `found_copyright` and `outdated_copyright`
+    mapfile -d $'\0' uptodate_copyright < <(                                       \
+        printf -- '%s\0' "${found_copyright[@]}" |                                 \
+        LANG=C.UTF-8 comm -z -23 - <(printf -- '%s\0' "${outdated_copyright[@]}"))
+
+    if (( ${#uptodate_copyright[@]} )); then
+        printf -- "\033[36mThe copyright statement was already up to date in %d file(s):\033[0m\n" \
+            "${#uptodate_copyright[@]}"
+        printf -- '  - %q\n' "${uptodate_copyright[@]}"
+    fi
+fi
+
+if ! (( ${#outdated_copyright[@]} )); then
+    exit 0
+fi
+
+printf -- \
+"\033[31m==== COPYRIGHT OUT OF DATE ====\033[0m
+\033[36m%d file(s) need(s) to be updated:\033[0m\n" "${#outdated_copyright[@]}"
+printf -- '  - %q\n' "${outdated_copyright[@]}"
+
+# If we don't need to update, we early exit.
+if ! $update; then
+    printf -- \
+"\nRun '\033[33mscripts/copyright-date/check-copyright.sh -u\033[0m' to update the copyright statement(s). See '-h' for more info,
+or set '\033[33mgit config --local hooks.updateCopyright true\033[0m' to automatically update copyrights when committing.\n"
+    exit 1
+fi
+
+if $apply; then
+    ! $quiet && printf -- "Updating copyrights and staging changes... "
+else
+    ! $quiet && printf -- "Updating copyrights... "
+fi
+
+# replace_pattern variable holds a format string, using it as such is intentional
+# shellcheck disable=SC2059
+printf -v replace_pattern -- "$replace_pattern" "$year"
+# Just update the files in place if only touching the working-tree
+if ! $apply; then
+    sed --regexp-extended --separate "s/$replace_pattern/g" -i "${outdated_copyright[@]}"
+    printf -- "\033[32mDone!\033[0m\n"
+    exit 0
+fi
+
+generate_patch() {
+    # Sed command to create a hunk for a copyright statement fix
+    # expects input to be line number then copyright statement on the next line
+    to_hunk_cmd="{# Print hunk header, move to the next line
+                  s/.+/@@ -&,1 +&,1 @@/;n
+                  # Print removed line by prepending '-' to it
+                  ;s/^/-/;p
+                  # Print added line, replace the '-' with '+' and replace the copyright statement
+                  s/^-/+/;s/$replace_pattern/g}"
+
+    # Run file-names through git ls-files, just to get a (possibly) quoted name for each
+    mapfile -t -d $'\n' quoted_files < <(git ls-files --cached -- "${outdated_copyright[@]}")
+    for ((i = 0;i < ${#outdated_copyright[@]}; i++)); do
+        file="${outdated_copyright["$i"]}"
+        quoted="${quoted_files["$i"]}"
+        # Drop the quote from the start and end (to avoid quoting twice)
+        escaped="${quoted#\"}"; escaped="${escaped%\"}"
+        a="\"a/$escaped\""
+        b="\"b/$escaped\""
+
+        printf -- "diff --git %s %s\n--- %s\n+++ %s\n" "$a" "$b" "$a" "$b"
+
+        # Print line number and line for each line with a copyright statement
+        git cat-file blob ":$file" |                               \
+            sed --quiet --regexp-extended "/$find_pattern/{=;p}" | \
+            sed --regexp-extended "$to_hunk_cmd"
+    done
+}
+
+patch_file="$(git rev-parse --git-dir)/copyright-fix.patch"
+generate_patch > "$patch_file"
+
+# Cleanup patch file when the script exits
+finish () {
+    rm -f "$patch_file"
+}
+# The trap will be invoked whenever the script exits, even due to a signal, this is a bash only
+# feature
+trap finish EXIT
+
+if ! git apply --unidiff-zero < "$patch_file"; then
+    printf -- "\033[31mFailed to apply changes to working tree.
+Perhaps the fix is already applied, but not yet staged?\n\033[0m"
+    exit 1
+fi
+
+if ! git apply --cached --unidiff-zero < "$patch_file"; then
+    printf -- "\033[31mFailed to apply change to the index.\n\033[0m"
+    exit 1
+fi
+
+! $quiet && printf -- "\033[32mDone!\033[0m\n"
+exit 0

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2019-2021 Advanced Micro Devices, Inc.
+# Copyright 2019-2023 Advanced Micro Devices, Inc.
 # ########################################################################
 
 set(INSTALL_TEST_FILE "${CMAKE_CURRENT_BINARY_DIR}/install_CTestTestfile.cmake")
@@ -53,15 +53,24 @@ function(add_rocthrust_test TEST)
     add_executable(${TEST_TARGET} ${TEST_SOURCE})
     target_include_directories(${TEST_TARGET} SYSTEM BEFORE
         PUBLIC
-            $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     )
     target_link_libraries(${TEST_TARGET}
         PRIVATE
             rocthrust
             roc::rocprim_hip
-            ${GTEST_BOTH_LIBRARIES}
     )
+    if (TARGET GTest::GTest)
+        target_link_libraries(${TEST_TARGET}
+                PRIVATE
+                GTest::GTest
+                GTest::Main)
+    else ()
+        target_link_libraries(${TEST_TARGET}
+                PRIVATE
+                GTest::gtest
+                GTest::gtest_main)
+    endif ()
     if (NOT WIN32)
       foreach(amdgpu_target ${AMDGPU_TARGETS})
           target_link_libraries(${TEST_TARGET}

--- a/test/test_allocator_aware_policies.cpp
+++ b/test/test_allocator_aware_policies.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2008-2018 NVIDIA Corporation
- *  Modifications Copyright© 2019-2020 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -122,11 +122,9 @@ struct TestAllocatorAttachment
         test_temporary_allocation_valid(policy(const_alloc));
         test_temporary_allocation_valid(policy(&test_memory_resource));
 
-        #if THRUST_CPP_DIALECT >= 2011
         test_temporary_allocation_valid(policy(std::allocator<int>()).after(1));
         test_temporary_allocation_valid(policy(alloc).after(1));
         test_temporary_allocation_valid(policy(const_alloc).after(1));
-        #endif
     }
 };
 

--- a/test/test_async_copy.cpp
+++ b/test/test_async_copy.cpp
@@ -1,7 +1,5 @@
 #include <thrust/detail/config.h>
 
-#if THRUST_CPP_DIALECT >= 2011
-
 #include <thrust/limits.h>
 #include <thrust/async/copy.h>
 #include <thrust/host_vector.h>
@@ -223,5 +221,3 @@ TYPED_TEST(AsyncCopyTests, TestAsyncCopyDevicetoDeviceWithPolicy)
 
 // TODO: H->D copy, then dependent D->H copy (round trip).
 // Can't do this today because we can't do cross-system with explicit policies.
-
-#endif // THRUST_CPP_DIALECT >= 2011

--- a/test/test_async_for_each.cpp
+++ b/test/test_async_for_each.cpp
@@ -1,7 +1,5 @@
 #include <thrust/detail/config.h>
 
-#if THRUST_CPP_DIALECT >= 2011 && !defined(THRUST_LEGACY_GCC)
-
 #include <thrust/async/for_each.h>
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
@@ -96,5 +94,3 @@ TYPED_TEST(AsyncForEachTests, TestAsyncForEachPolicy)
         , inplace_divide_by_2
     >();
 }
-
-#endif

--- a/test/test_async_reduce.cpp
+++ b/test/test_async_reduce.cpp
@@ -1,7 +1,5 @@
 #include <thrust/detail/config.h>
 
-#if THRUST_CPP_DIALECT >= 2011 && !defined(THRUST_LEGACY_GCC)
-
 #include <thrust/async/reduce.h>
 #include <thrust/async/copy.h>
 #include <thrust/host_vector.h>
@@ -1215,5 +1213,3 @@ TYPED_TEST(AsyncReduceTests, TestAsyncCopyThenReduce)
 ///////////////////////////////////////////////////////////////////////////////
 
 // TODO: when_all from reductions.
-
-#endif

--- a/test/test_async_scan.cpp
+++ b/test/test_async_scan.cpp
@@ -1,7 +1,5 @@
 #include <thrust/detail/config.h>
 
-#if THRUST_CPP_DIALECT >= 2011
-
 #include <thrust/async/scan.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
@@ -222,5 +220,3 @@ TYPED_TEST(AsyncScanTests, AsyncExclusiveScanPolicyMaximumNoWait)
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-
-#endif // THRUST_CPP_DIALECT >= 2011

--- a/test/test_async_sort.cpp
+++ b/test/test_async_sort.cpp
@@ -1,7 +1,5 @@
 #include <thrust/detail/config.h>
 
-#if THRUST_CPP_DIALECT >= 2011
-
 #include <thrust/async/sort.h>
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
@@ -317,5 +315,3 @@ TYPED_TEST(AsyncSortTests, AsyncSortPolicyCustomGreaterNoWait)
 // TODO: Async copy then sort.
 
 // TODO: Test future return type.
-
-#endif // THRUST_CPP_DIALECT >= 2011

--- a/test/test_async_transform.cpp
+++ b/test/test_async_transform.cpp
@@ -1,11 +1,8 @@
-#include <thrust/detail/config.h>
-
-#if THRUST_CPP_DIALECT >= 2011 && !defined(THRUST_LEGACY_GCC)
-
 #include <thrust/async/transform.h>
 #include <thrust/async/copy.h>
-#include <thrust/host_vector.h>
+#include <thrust/detail/config.h>
 #include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 
 #include "test_header.hpp"
 
@@ -418,4 +415,3 @@ TYPED_TEST(AsyncTransformTests, TestAsyncTransformUnaryInplaceDeviceAllocatorOn)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#endif

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2008-2013 NVIDIA Corporation
- *  Modifications Copyright© 2019 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -420,9 +420,7 @@ struct TypeWithNonTrivialAssigment
     {
     }
 
-#if THRUST_CPP_DIALECT >= 2011
-    TypeWithNonTrivialAssigment(const TypeWithNonTrivialAssigment &) = default;
-#endif
+    TypeWithNonTrivialAssigment(const TypeWithNonTrivialAssigment&) = default;
 
     __host__ __device__ TypeWithNonTrivialAssigment& operator=(const TypeWithNonTrivialAssigment& t)
     {

--- a/test/test_header.hpp
+++ b/test/test_header.hpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2008-2013 NVIDIA Corporation
- *  Modifications Copyright© 2019 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -54,8 +54,8 @@ int set_device_from_ctest()
         std::transform(amdgpu_target.cbegin(), amdgpu_target.cend(), amdgpu_target.begin(), ::toupper);
         std::string reqs = std::getenv((rg0 + "_" + amdgpu_target).c_str());
         int device_id = std::atoi(reqs.substr(reqs.find(':') + 1, reqs.find(',') - (reqs.find(':') + 1)).c_str());
-        hipSetDevice(device_id);
-        return device_id; 
+        hipError_t status = hipSetDevice(device_id);
+        return status == hipSuccess ? device_id : 0;
     }
     else
         return 0;

--- a/test/test_header.hpp
+++ b/test/test_header.hpp
@@ -192,7 +192,7 @@ typedef ::testing::Types<Params<short>,
 // Scalar signed interger types
 typedef ::testing::Types<Params<short>, Params<int>, Params<long long>> SignedIntegerTestsParams;
 
-#if defined(WIN32) && defined(__HIP__)
+#if defined(_WIN32) && defined(__HIP__)
 // Scalar unsigned interger types of all lengths
 typedef ::testing::Types<Params<thrust::detail::uint16_t>,
                          Params<thrust::detail::uint32_t>,

--- a/test/test_header.hpp
+++ b/test/test_header.hpp
@@ -55,7 +55,11 @@ int set_device_from_ctest()
         std::string reqs = std::getenv((rg0 + "_" + amdgpu_target).c_str());
         int device_id = std::atoi(reqs.substr(reqs.find(':') + 1, reqs.find(',') - (reqs.find(':') + 1)).c_str());
         hipError_t status = hipSetDevice(device_id);
-        return status == hipSuccess ? device_id : 0;
+        if(status != hipSuccess)
+        {
+            [] { FAIL() << "could not set HIP device"; }();
+        }
+        return device_id;
     }
     else
         return 0;

--- a/test/test_is_sorted.cpp
+++ b/test/test_is_sorted.cpp
@@ -39,13 +39,7 @@ TYPED_TEST(IsSortedVectorTests, TestIsSortedSimple)
     ASSERT_EQ(thrust::is_sorted(v.begin(), v.begin() + 0), true);
     ASSERT_EQ(thrust::is_sorted(v.begin(), v.begin() + 1), true);
 
-    // the following line crashes gcc 4.3
-#if(__GNUC__ == 4) && (__GNUC_MINOR__ == 3)
-    // do nothing
-#else
-    // compile this line on other compilers
     ASSERT_EQ(thrust::is_sorted(v.begin(), v.begin() + 2), true);
-#endif // GCC
 
     ASSERT_EQ(thrust::is_sorted(v.begin(), v.begin() + 3), true);
     ASSERT_EQ(thrust::is_sorted(v.begin(), v.begin() + 4), false);

--- a/test/test_mr_disjoint_pool.cpp
+++ b/test/test_mr_disjoint_pool.cpp
@@ -1,11 +1,9 @@
 #include <thrust/mr/disjoint_pool.h>
+#include <thrust/mr/disjoint_sync_pool.h>
 #include <thrust/mr/new.h>
 
 #include "test_header.hpp"
 
-#if __cplusplus >= 201103L
-#include <thrust/mr/disjoint_sync_pool.h>
-#endif
 
 struct alloc_id
 {
@@ -177,14 +175,12 @@ TEST(MrDisjointPoolTests, TestDisjointUnsynchronizedPool)
     TestDisjointPool<thrust::mr::disjoint_unsynchronized_pool_resource>();
 }
 
-#if __cplusplus >= 201103L
 TEST(MrDisjointPoolTests, TestDisjointSynchronizedPool)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     TestDisjointPool<thrust::mr::disjoint_synchronized_pool_resource>();
 }
-#endif
 
 template<template<typename, typename> class PoolTemplate>
 void TestDisjointPoolCachingOversized()
@@ -262,14 +258,12 @@ TEST(MrDisjointPoolTests, TestDisjointUnsynchronizedPoolCachingOversized)
     TestDisjointPoolCachingOversized<thrust::mr::disjoint_unsynchronized_pool_resource>();
 }
 
-#if __cplusplus >= 201103L
 TEST(MrDisjointPoolTests, TestDisjointSynchronizedPoolCachingOversized)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     TestDisjointPoolCachingOversized<thrust::mr::disjoint_synchronized_pool_resource>();
 }
-#endif
 
 template<template<typename, typename> class PoolTemplate>
 void TestDisjointGlobalPool()
@@ -289,11 +283,9 @@ TEST(MrDisjointPoolTests, TestUnsynchronizedDisjointGlobalPool)
     TestDisjointGlobalPool<thrust::mr::disjoint_unsynchronized_pool_resource>();
 }
 
-#if __cplusplus >= 201103L
 TEST(MrDisjointPoolTests, TestSynchronizedDisjointGlobalPool)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     TestDisjointGlobalPool<thrust::mr::disjoint_synchronized_pool_resource>();
 }
-#endif

--- a/test/test_mr_pool.cpp
+++ b/test/test_mr_pool.cpp
@@ -1,9 +1,7 @@
 #include <thrust/mr/pool.h>
+#include <thrust/mr/sync_pool.h>
 #include <thrust/mr/new.h>
 
-#if __cplusplus >= 201103L
-#include <thrust/mr/sync_pool.h>
-#endif
 
 #include "test_header.hpp"
 
@@ -243,14 +241,12 @@ TEST(MrPoolTests, TestUnsynchronizedPool)
     TestPool<thrust::mr::unsynchronized_pool_resource>();
 }
 
-#if __cplusplus >= 201103L
 TEST(MrPoolTests, TestSynchronizedPool)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     TestPool<thrust::mr::synchronized_pool_resource>();
 }
-#endif
 
 template<template<typename> class PoolTemplate>
 void TestPoolCachingOversized()
@@ -328,14 +324,12 @@ TEST(MrPoolTests, TestUnsynchronizedPoolCachingOversized)
     TestPoolCachingOversized<thrust::mr::unsynchronized_pool_resource>();
 }
 
-#if __cplusplus >= 201103L
 TEST(MrPoolTests, TestSynchronizedPoolCachingOversized)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     TestPoolCachingOversized<thrust::mr::synchronized_pool_resource>();
 }
-#endif
 
 template<template<typename> class PoolTemplate>
 void TestGlobalPool()
@@ -354,11 +348,9 @@ TEST(MrPoolTests, TestUnsynchronizedGlobalPool)
     TestGlobalPool<thrust::mr::unsynchronized_pool_resource>();
 }
 
-#if __cplusplus >= 201103L
 TEST(MrPoolTests, TestSynchronizedGlobalPool)
 {
     SCOPED_TRACE(testing::Message() << "with device_id= " << test::set_device_from_ctest());
 
     TestGlobalPool<thrust::mr::synchronized_pool_resource>();
 }
-#endif

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2008-2013 NVIDIA Corporation
- *  Modifications Copyright© 2019 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -743,8 +743,6 @@ TEST(ScanTests, TestExclusiveScanDevice)
     }
 }
 
-#if THRUST_CPP_DIALECT >= 2011
-
 struct Int {
     int i{};
     __host__ __device__ explicit Int(int num) : i(num) {}
@@ -764,5 +762,3 @@ TEST(ScanTests, TestInclusiveScanWithUserDefinedType)
 
     ASSERT_EQ(static_cast<Int>(vec.back()).i, 5);
 }
-
-#endif // c++11

--- a/test/test_shuffle.cpp
+++ b/test/test_shuffle.cpp
@@ -1,6 +1,5 @@
 #include <thrust/detail/config.h>
 
-#if THRUST_CPP_DIALECT >= 2011
 #include <map>
 #include <limits>
 #include <thrust/random.h>
@@ -639,5 +638,3 @@ TYPED_TEST(ShuffleVectorTests, TestShuffleEvenDistribution)
       }
     }
 }
-
-#endif

--- a/test/test_swap_ranges.cpp
+++ b/test/test_swap_ranges.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2008-2013 NVIDIA Corporation
- *  Modifications Copyright© 2019 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -192,9 +192,7 @@ struct type_with_swap
         return m_x == other.m_x && m_swapped == other.m_swapped;
     }
 
-#if THRUST_CPP_DIALECT >= 2011
-    type_with_swap & operator=(const type_with_swap &) = default;
-#endif
+    type_with_swap& operator=(const type_with_swap&) = default;
 
     int  m_x;
     bool m_swapped;

--- a/test/test_transform_iterator.cpp
+++ b/test/test_transform_iterator.cpp
@@ -161,5 +161,5 @@ TEST(TransformIteratorTests, TestDeviceOperator)
 {
     thrust::device_vector<int> dv(1);
     auto                       iter = thrust::make_transform_iterator(dv.begin(), DeviceOp {});
-    (void)iter;
+    THRUST_UNUSED_VAR(iter);
 }

--- a/test/test_transform_iterator.cpp
+++ b/test/test_transform_iterator.cpp
@@ -161,4 +161,5 @@ TEST(TransformIteratorTests, TestDeviceOperator)
 {
     thrust::device_vector<int> dv(1);
     auto                       iter = thrust::make_transform_iterator(dv.begin(), DeviceOp {});
+    (void)iter;
 }

--- a/test/test_transform_iterator.cpp
+++ b/test/test_transform_iterator.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2008-2013 NVIDIA Corporation
- *  Modifications Copyright© 2019-21 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -146,4 +146,19 @@ TEST(TransformIteratorTests, TestTransformIteratorNonCopyable)
     ASSERT_EQ(transformed[1], 2);
     ASSERT_EQ(transformed[2], 3);
     ASSERT_EQ(transformed[3], 4);
+}
+
+struct DeviceOp
+{
+    __device__ int operator()(int)
+    {
+        return int {};
+    }
+};
+
+/// Tests compilation of device-only operators.
+TEST(TransformIteratorTests, TestDeviceOperator)
+{
+    thrust::device_vector<int> dv(1);
+    auto                       iter = thrust::make_transform_iterator(dv.begin(), DeviceOp {});
 }

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -191,7 +191,7 @@ inline auto get_random_data(size_t size, T min, T max, int seed) ->
     return data;
 }
 
-#if defined(WIN32) && defined(__clang__)
+#if defined(_WIN32) && defined(__clang__)
 template <>
 inline thrust::host_vector<unsigned char> get_random_data(size_t size, unsigned char min, unsigned char max, int seed_value)
 {

--- a/test/test_vector_allocators.cpp
+++ b/test/test_vector_allocators.cpp
@@ -24,7 +24,6 @@ public:
         return *this;
     }
 
-#if __cplusplus >= 201103L
     stateful_allocator(stateful_allocator && other)
         : BaseAlloc(std::move(other)), state(other.state)
     {
@@ -37,7 +36,6 @@ public:
         other.state = 0;
         return *this;
     }
-#endif
 
     static int last_allocated;
     static int last_deallocated;
@@ -130,7 +128,6 @@ void TestVectorAllocatorConstructors()
     ASSERT_EQ(Alloc::last_allocated, 2);
     Alloc::last_allocated = 0;
 
-#if __cplusplus >= 201103L
     // FIXME: uncomment this after the vector_base(vector_base&&, const Alloc&)
     // is fixed and implemented
     // Vector v5(std::move(v3), alloc2);
@@ -138,7 +135,6 @@ void TestVectorAllocatorConstructors()
     // ASSERT_EQ(v5.get_allocator(), alloc2);
     // ASSERT_EQ(Alloc::last_allocated, 1);
     // Alloc::last_allocated = 0;
-#endif
 
     Vector v6(v4.begin(), v4.end(), alloc2);
     ASSERT_EQ((v4 == v6), true);
@@ -193,7 +189,6 @@ TEST(VectorAllocatorTests, TestVectorAllocatorPropagateOnCopyAssignmentDevice)
     TestVectorAllocatorPropagateOnCopyAssignment<device_vector>();
 }
 
-#if __cplusplus >= 201103L
 template<typename Vector>
 void TestVectorAllocatorPropagateOnMoveAssignment()
 {
@@ -230,8 +225,6 @@ TEST(VectorAllocatorTests, TestVectorAllocatorPropagateOnMoveAssignmentDevice)
 
     TestVectorAllocatorPropagateOnMoveAssignment<device_vector>();
 }
-
-#endif
 
 template<typename Vector>
 void TestVectorAllocatorPropagateOnSwap()

--- a/test/test_zip_iterator_sort_by_key.cpp
+++ b/test/test_zip_iterator_sort_by_key.cpp
@@ -20,7 +20,7 @@
 
 #include "test_header.hpp"
 
-#if defined(WIN32) && defined(__HIP__)
+#if defined(_WIN32) && defined(__HIP__)
 typedef ::testing::Types<Params<int16_t>, Params<int32_t>> TestParams;
 #else
 typedef ::testing::Types<Params<int8_t>, Params<int16_t>, Params<int32_t>> TestParams;

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2019 - 2020 Advanced Micro Devices, Inc.
+# Copyright 2019 - 2023 Advanced Micro Devices, Inc.
 # ########################################################################
 
 add_library(testing_common INTERFACE)
@@ -7,15 +7,24 @@ target_include_directories(testing_common
     SYSTEM
     BEFORE
     INTERFACE
-        $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
 )
 target_link_libraries(testing_common
     INTERFACE
         rocthrust
         roc::rocprim_hip
-        ${GTEST_BOTH_LIBRARIES}
 )
+if (TARGET GTest::GTest)
+    target_link_libraries(testing_common
+            INTERFACE
+            GTest::GTest
+            GTest::Main)
+else ()
+    target_link_libraries(testing_common
+            INTERFACE
+            GTest::gtest
+            GTest::gtest_main)
+endif ()
 foreach(amdgpu_target ${AMDGPU_TARGETS})
     target_link_libraries(testing_common
         INTERFACE

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -43,7 +43,7 @@ if(HIP_COMPILER STREQUAL "nvcc")
             LANGUAGE CXX
     )
     target_sources(testframework PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/unittest/cuda/testframework.cu)
-elseif(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
+elseif(HIP_COMPILER STREQUAL "clang")
     set_source_files_properties(unittest/hip/testframework.cu
     PROPERTIES
         LANGUAGE CXX

--- a/testing/unittest/hip/testframework.cu
+++ b/testing/unittest/hip/testframework.cu
@@ -61,13 +61,6 @@ void list_devices(void)
   std::cout << std::endl;
 }
 
-// provide next, which c++03 doesn't have
-template<typename Iterator> Iterator my_next(Iterator iter)
-{
-  return ++iter;
-}
-
-
 std::vector<int> HIPTestDriver::target_devices(const ArgumentMap &kwargs)
 {
   std::vector<int> result;
@@ -198,7 +191,7 @@ bool HIPTestDriver::run_tests(const ArgumentSet &args, const ArgumentMap &kwargs
     // run tests
     result &= UnitTestDriver::run_tests(args, kwargs);
 
-    if(!concise && my_next(device) != devices.end())
+    if(!concise && std::next(device) != devices.end())
     {
       // provide some separation between the output of separate tests
       std::cout << std::endl;

--- a/testing/unittest/runtime_static_assert.h
+++ b/testing/unittest/runtime_static_assert.h
@@ -20,21 +20,49 @@ namespace unittest
 
 #if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA || THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_HIP
 
-#define ASSERT_STATIC_ASSERT(X) \
-    { \
-        bool triggered = false; \
-        typedef unittest::static_assert_exception ex_t; \
-        thrust::device_ptr<ex_t> device_ptr = thrust::device_new<ex_t>(); \
-        ex_t* raw_ptr = thrust::raw_pointer_cast(device_ptr); \
-        ::hipMemcpyToSymbol(unittest::detail::device_exception, &raw_ptr, sizeof(ex_t*)); \
-        try { X; } catch (ex_t) { triggered = true; } \
-        if (!triggered) { \
-            triggered = static_cast<ex_t>(*device_ptr).triggered; \
-        } \
-        thrust::device_free(device_ptr); \
-        raw_ptr = NULL; \
-        ::hipMemcpyToSymbol(unittest::detail::device_exception, &raw_ptr, sizeof(ex_t*)); \
-        if (!triggered) { unittest::UnitTestFailure f; f << "[" << __FILE__ << ":" << __LINE__ << "] did not trigger a THRUST_STATIC_ASSERT"; throw f; } \
+#define ASSERT_STATIC_ASSERT(X)                                                                      \
+    {                                                                                                \
+        bool                                      triggered = false;                                 \
+        typedef unittest::static_assert_exception ex_t;                                              \
+        thrust::device_ptr<ex_t>                  device_ptr = thrust::device_new<ex_t>();           \
+        ex_t*                                     raw_ptr    = thrust::raw_pointer_cast(device_ptr); \
+        hipError_t                                err                                                \
+            = ::hipMemcpyToSymbol(unittest::detail::device_exception, &raw_ptr, sizeof(ex_t*));      \
+        if(err != hipSuccess)                                                                        \
+        {                                                                                            \
+            thrust::device_free(device_ptr);                                                         \
+            raw_ptr = NULL;                                                                          \
+            unittest::UnitTestFailure f;                                                             \
+            f << "[" << __FILE__ << ":" << __LINE__ << "] hipMemcpyToSymbol failed";                 \
+            throw f;                                                                                 \
+        }                                                                                            \
+        try                                                                                          \
+        {                                                                                            \
+            X;                                                                                       \
+        }                                                                                            \
+        catch(ex_t)                                                                                  \
+        {                                                                                            \
+            triggered = true;                                                                        \
+        }                                                                                            \
+        if(!triggered)                                                                               \
+        {                                                                                            \
+            triggered = static_cast<ex_t>(*device_ptr).triggered;                                    \
+        }                                                                                            \
+        thrust::device_free(device_ptr);                                                             \
+        raw_ptr = NULL;                                                                              \
+        err     = ::hipMemcpyToSymbol(unittest::detail::device_exception, &raw_ptr, sizeof(ex_t*));  \
+        if(err != hipSuccess)                                                                        \
+        {                                                                                            \
+            unittest::UnitTestFailure f;                                                             \
+            f << "[" << __FILE__ << ":" << __LINE__ << "] hipMemcpyToSymbol failed";                 \
+            throw f;                                                                                 \
+        }                                                                                            \
+        if(!triggered)                                                                               \
+        {                                                                                            \
+            unittest::UnitTestFailure f;                                                             \
+            f << "[" << __FILE__ << ":" << __LINE__ << "] did not trigger a THRUST_STATIC_ASSERT";   \
+            throw f;                                                                                 \
+        }                                                                                            \
     }
 
 #else

--- a/thrust/detail/config/compiler.h
+++ b/thrust/detail/config/compiler.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#if defined(__HCC__) || defined(__HIP__)
+#if defined(__HIP__)
 // Macro enables Device Malloc
 #ifndef __HIP_ENABLE_DEVICE_MALLOC__
 #define __HIP_ENABLE_DEVICE_MALLOC__ 1
@@ -83,7 +83,7 @@
 // CUDA-capable clang should behave similar to NVCC.
 #if defined(__CUDA__)
 #define THRUST_DEVICE_COMPILER THRUST_DEVICE_COMPILER_NVCC
-#elif defined(__HCC__) || defined(__HIP__)
+#elif defined(__HIP__)
 #define THRUST_DEVICE_COMPILER THRUST_DEVICE_COMPILER_HIP
 #else
 #define THRUST_DEVICE_COMPILER THRUST_DEVICE_COMPILER_CLANG

--- a/thrust/detail/pointer.h
+++ b/thrust/detail/pointer.h
@@ -165,7 +165,7 @@ template<typename Element, typename Tag, typename Reference, typename Derived>
     __host__ __device__
     explicit pointer(OtherElement *ptr);
 
-    // Fixes HCC linkage error
+    // Fixes hipcc linkage error
     __host__ __device__
     explicit pointer(Element *ptr);
 

--- a/thrust/detail/pointer.inl
+++ b/thrust/detail/pointer.inl
@@ -48,7 +48,7 @@ template<typename Element, typename Tag, typename Reference, typename Derived>
         : super_t(other)
 {} // end pointer::pointer
 
-// Fixes HCC linkage error
+// Fixes hipcc linkage error
 template<typename Element, typename Tag, typename Reference, typename Derived>
   __host__ __device__
   pointer<Element,Tag,Reference,Derived>

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -170,10 +170,11 @@ template<typename T> struct has_trivial_copy_constructor
       || __is_trivially_copyable(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER
-    >
-{};
+                                                                >
+ {
+ };
 
-template<typename T> struct has_trivial_destructor : public is_pod<T> {};
+ template<typename T> struct has_trivial_destructor : public is_pod<T> {};
 
 template<typename T> struct is_const          : public false_type {};
 template<typename T> struct is_const<const T> : public true_type {};

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -157,24 +157,26 @@ template<typename T> struct has_trivial_constructor
       >
 {};
 
-template<typename T> struct has_trivial_copy_constructor
-  : public integral_constant<
-      bool,
-      is_pod<T>::value
+template <typename T>
+struct has_trivial_copy_constructor : public integral_constant<bool,
+                                                               is_pod<T>::value
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
-      || __is_trivially_copyable(T)
+                                                                   || __is_trivially_copyable(T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
 // only use the intrinsic for >= 4.3
 #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
-      || __is_trivially_copyable(T)
+                                                                    || __is_trivially_copyable(T)
 #endif // GCC VERSION
 #endif // THRUST_HOST_COMPILER
-                                                                >
- {
- };
+                                                               >
+{
+};
 
- template<typename T> struct has_trivial_destructor : public is_pod<T> {};
+template <typename T>
+struct has_trivial_destructor : public is_pod<T>
+{
+};
 
 template<typename T> struct is_const          : public false_type {};
 template<typename T> struct is_const<const T> : public true_type {};

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -1,5 +1,6 @@
 /*
- *  Copyright 2008-2018 NVIDIA Corporation
+ *  Copyright 2008-2022 NVIDIA Corporation
+ *  Modifications Copyright© 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,9 +25,13 @@
 
 #include <thrust/detail/config.h>
 
-#if THRUST_CPP_DIALECT >= 2011
-#  include <type_traits>
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_HIP
+#include <rocprim/detail/match_result_type.hpp>
+#elif THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+#include <cuda/std/type_traits>
 #endif
+
+#include <type_traits>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -47,7 +52,6 @@ namespace detail
      // We don't want to switch to std::integral_constant, because we want access
      // to the C++14 operator(), but we'd like standard traits to interoperate
      // with our version when tag dispatching.
-     #if THRUST_CPP_DIALECT >= 2011
      integral_constant() = default;
 
      integral_constant(integral_constant const&) = default;
@@ -56,7 +60,6 @@ namespace detail
 
      constexpr __host__ __device__
      integral_constant(std::integral_constant<T, v>) noexcept {}
-     #endif
 
      constexpr __host__ __device__ operator value_type() const noexcept { return value; }
      constexpr __host__ __device__ value_type operator()() const noexcept { return value; }
@@ -568,15 +571,7 @@ template<typename T>
 
 struct largest_available_float
 {
-#if defined(__CUDA_ARCH__)
-#  if (__CUDA_ARCH__ < 130)
-  typedef float type;
-#  else
   typedef double type;
-#  endif
-#else
-  typedef double type;
-#endif
 };
 
 // T1 wins if they are both the same size
@@ -649,7 +644,7 @@ template<typename T1, typename T2>
   typedef struct { char array[2]; } no_type;
 
   template<typename T> static typename add_reference<T>::type declval();
-  
+
   template<size_t> struct helper { typedef void * type; };
 
   template<typename U1, typename U2> static yes_type test(typename helper<sizeof(declval<U1>() = declval<U2>())>::type);
@@ -722,6 +717,24 @@ template<typename T>
   >
   {
   };
+
+template <typename Invokable, typename... Args>
+using invoke_result_t =
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_HIP
+      typename ::rocprim::detail::invoke_result<Invokable, Args...>::type;
+#elif THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+#if THRUST_CPP_DIALECT < 2017
+  typename ::cuda::std::result_of<Invokable(Args...)>::type;
+#else // 2017+
+  ::cuda::std::invoke_result_t<Invokable, Args...>;
+#endif
+#endif
+
+template <class F, class... Us>
+struct invoke_result
+{
+  using type = invoke_result_t<F, Us...>;
+};
 
 } // end detail
 

--- a/thrust/detail/type_traits/has_trivial_assign.h
+++ b/thrust/detail/type_traits/has_trivial_assign.h
@@ -1,5 +1,6 @@
 /*
  *  Copyright 2008-2013 NVIDIA Corporation
+ *  Modifications Copyright© 2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,10 +31,9 @@ THRUST_NAMESPACE_BEGIN
 namespace detail
 {
 
-template<typename T> struct has_trivial_assign
-  : public integral_constant<
-      bool,
-      (is_pod<T>::value && !is_const<T>::value)
+template <typename T>
+struct has_trivial_assign : public integral_constant<bool,
+                                                     (is_pod<T>::value && !is_const<T>::value)
 #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC
       || __is_trivially_assignable(T, const T)
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
@@ -44,8 +44,9 @@ template<typename T> struct has_trivial_assign
 #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
       || __is_trivially_assignable(T, const T)
 #endif // THRUST_HOST_COMPILER
-    >
-{};
+                                                     >
+{
+};
 
 } // end detail
 

--- a/thrust/detail/type_traits/result_of_adaptable_function.h
+++ b/thrust/detail/type_traits/result_of_adaptable_function.h
@@ -29,7 +29,6 @@ namespace detail
 // Sets `type` to the result of the specified Signature invocation. If the
 // callable defines a `result_type` alias member, that type is used instead.
 // Use invoke_result / result_of when FuncType::result_type is not defined.
-#if THRUST_CPP_DIALECT >= 2017
 template <typename Signature, typename Enable = void>
 struct result_of_adaptable_function
 {
@@ -39,16 +38,12 @@ private:
   template <typename F, typename...Args>
   struct impl<F(Args...)>
   {
-    using type = std::invoke_result_t<F, Args...>;
+    using type = invoke_result_t<F, Args...>;
   };
 
 public:
   using type = typename impl<Signature>::type;
 };
-#else // < C++17
-template <typename Signature, typename Enable = void>
-struct result_of_adaptable_function : std::result_of<Signature> {};
-#endif // < C++17
 
 // specialization for invocations which define result_type
 template <typename Functor, typename... ArgTypes>

--- a/thrust/device_ptr.h
+++ b/thrust/device_ptr.h
@@ -111,10 +111,6 @@ class device_ptr
     __host__ __device__
     explicit device_ptr(U* ptr) : super_t(ptr) {}
 
-    // Fixes HCC linkage error
-    __host__ __device__
-    explicit device_ptr(T *ptr) : super_t(ptr) {}
-
     /*! \brief Copy construct a \c device_ptr from another \c device_ptr whose
      *  pointer type is convertible to \c T*.
      *

--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -255,22 +255,6 @@ constexpr auto invoke(Fn &&f, Args &&... args)
 {
   return std::forward<Fn>(f)(std::forward<Args>(args)...);
 }
-
-// std::invoke_result from C++17
-template <class F, class, class... Us> struct invoke_result_impl;
-
-template <class F, class... Us>
-struct invoke_result_impl<
-    F, decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...), void()),
-    Us...> {
-  using type = decltype(detail::invoke(std::declval<F>(), std::declval<Us>()...));
-};
-
-template <class F, class... Us>
-using invoke_result = invoke_result_impl<F, void, Us...>;
-
-template <class F, class... Us>
-using invoke_result_t = typename invoke_result<F, Us...>::type;
 #endif
 
 // std::void_t from C++17

--- a/thrust/system/hip/detail/adjacent_difference.h
+++ b/thrust/system/hip/detail/adjacent_difference.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019-2022, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -417,7 +417,6 @@ adjacent_difference(execution_policy<Derived>& policy,
                     BinaryOp                   binary_op)
 {
     // struct workaround is required for HIP-clang
-    // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
     struct workaround
     {
         __host__
@@ -427,19 +426,8 @@ adjacent_difference(execution_policy<Derived>& policy,
                         OutputIt&                  result,
                         BinaryOp                   binary_op)
         {
-        #if __HCC__ && __HIP_DEVICE_COMPILE__
-        THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-            (__adjacent_difference::adjacent_difference<Derived, InputIt, OutputIt, BinaryOp>)
-        );
-        #else
-        result = __adjacent_difference::adjacent_difference(
-            policy,
-            first,
-            last,
-            result,
-            binary_op
-        );
-        #endif
+            result = __adjacent_difference::adjacent_difference(
+                policy, first, last, result, binary_op);
         }
         __device__
         static void seq(execution_policy<Derived>& policy,

--- a/thrust/system/hip/detail/binary_search.h
+++ b/thrust/system/hip/detail/binary_search.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019-2022, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -246,50 +246,37 @@ lower_bound(execution_policy<Derived>& policy,
             OutputIt                   result,
             CompareOp                  compare_op)
 {
-  struct workaround
-  {
-      __host__
-      static OutputIt par(execution_policy<Derived>& policy,
-                          HaystackIt                 first,
-                          HaystackIt                 last,
-                          NeedlesIt                  values_first,
-                          NeedlesIt                  values_last,
-                          OutputIt                   result,
-                          CompareOp                  compare_op)
-      {
-        #if __HCC__ && __HIP_DEVICE_COMPILE__
-          THRUST_HIP_PRESERVE_KERNELS_WORKAROUND
-          (__binary_search::lower_bound<Derived,
-                                        HaystackIt,
-                                        NeedlesIt,
-                                        OutputIt,
-                                        CompareOp>);
-          return first;
-        #else
-        return __binary_search::lower_bound(
-            policy, first, last, values_first, values_last, result, compare_op
-        );
-        #endif
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIt par(execution_policy<Derived>& policy,
+                                     HaystackIt                 first,
+                                     HaystackIt                 last,
+                                     NeedlesIt                  values_first,
+                                     NeedlesIt                  values_last,
+                                     OutputIt                   result,
+                                     CompareOp                  compare_op)
+        {
+            return __binary_search::lower_bound(
+                policy, first, last, values_first, values_last, result, compare_op);
+        }
 
-
-      __device__
-      static OutputIt seq(execution_policy<Derived>& policy,
-                          HaystackIt                 first,
-                          HaystackIt                 last,
-                          NeedlesIt                  values_first,
-                          NeedlesIt                  values_last,
-                          OutputIt                   result,
-                          CompareOp                  compare_op)
-      {
-        return thrust::lower_bound(cvt_to_seq(derived_cast(policy)),
-                                   first,
-                                   last,
-                                   values_first,
-                                   values_last,
-                                   result,
-                                   compare_op);
-      }
+        __device__ static OutputIt seq(execution_policy<Derived>& policy,
+                                       HaystackIt                 first,
+                                       HaystackIt                 last,
+                                       NeedlesIt                  values_first,
+                                       NeedlesIt                  values_last,
+                                       OutputIt                   result,
+                                       CompareOp                  compare_op)
+        {
+            return thrust::lower_bound(cvt_to_seq(derived_cast(policy)),
+                                       first,
+                                       last,
+                                       values_first,
+                                       values_last,
+                                       result,
+                                       compare_op);
+        }
   };
 
   #if __THRUST_HAS_HIPRT__
@@ -326,51 +313,37 @@ upper_bound(execution_policy<Derived>& policy,
             OutputIt                   result,
             CompareOp                  compare_op)
 {
-  struct workaround
-  {
-      __host__
-      static OutputIt par(execution_policy<Derived>& policy,
-                          HaystackIt                 first,
-                          HaystackIt                 last,
-                          NeedlesIt                  values_first,
-                          NeedlesIt                  values_last,
-                          OutputIt                   result,
-                          CompareOp                  compare_op)
-      {
-        #if __HCC__ && __HIP_DEVICE_COMPILE__
-          THRUST_HIP_PRESERVE_KERNELS_WORKAROUND
-          (__binary_search::upper_bound<Derived,
-                                        HaystackIt,
-                                        NeedlesIt,
-                                        OutputIt,
-                                        CompareOp>);
-          return first;
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIt par(execution_policy<Derived>& policy,
+                                     HaystackIt                 first,
+                                     HaystackIt                 last,
+                                     NeedlesIt                  values_first,
+                                     NeedlesIt                  values_last,
+                                     OutputIt                   result,
+                                     CompareOp                  compare_op)
+        {
+            return __binary_search::upper_bound(
+                policy, first, last, values_first, values_last, result, compare_op);
+        }
 
-        #else
-        return __binary_search::upper_bound(
-            policy, first, last, values_first, values_last, result, compare_op
-        );
-        #endif
-      }
-
-
-      __device__
-      static OutputIt seq(execution_policy<Derived>& policy,
-                          HaystackIt                 first,
-                          HaystackIt                 last,
-                          NeedlesIt                  values_first,
-                          NeedlesIt                  values_last,
-                          OutputIt                   result,
-                          CompareOp                  compare_op)
-      {
-        return thrust::upper_bound(cvt_to_seq(derived_cast(policy)),
-                                   first,
-                                   last,
-                                   values_first,
-                                   values_last,
-                                   result,
-                                   compare_op);
-      }
+        __device__ static OutputIt seq(execution_policy<Derived>& policy,
+                                       HaystackIt                 first,
+                                       HaystackIt                 last,
+                                       NeedlesIt                  values_first,
+                                       NeedlesIt                  values_last,
+                                       OutputIt                   result,
+                                       CompareOp                  compare_op)
+        {
+            return thrust::upper_bound(cvt_to_seq(derived_cast(policy)),
+                                       first,
+                                       last,
+                                       values_first,
+                                       values_last,
+                                       result,
+                                       compare_op);
+        }
   };
 
   #if __THRUST_HAS_HIPRT__
@@ -405,51 +378,37 @@ binary_search(execution_policy<Derived>& policy,
               OutputIt                   result,
               CompareOp                  compare_op)
 {
-  struct workaround
-  {
-      __host__
-      static OutputIt par(execution_policy<Derived>& policy,
-                          HaystackIt                 first,
-                          HaystackIt                 last,
-                          NeedlesIt                  values_first,
-                          NeedlesIt                  values_last,
-                          OutputIt                   result,
-                          CompareOp                  compare_op)
-      {
-        #if __HCC__ && __HIP_DEVICE_COMPILE__
-          THRUST_HIP_PRESERVE_KERNELS_WORKAROUND
-          (__binary_search::binary_search<Derived,
-                                        HaystackIt,
-                                        NeedlesIt,
-                                        OutputIt,
-                                        CompareOp>);
-          return first;
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIt par(execution_policy<Derived>& policy,
+                                     HaystackIt                 first,
+                                     HaystackIt                 last,
+                                     NeedlesIt                  values_first,
+                                     NeedlesIt                  values_last,
+                                     OutputIt                   result,
+                                     CompareOp                  compare_op)
+        {
+            return __binary_search::binary_search(
+                policy, first, last, values_first, values_last, result, compare_op);
+        }
 
-        #else
-        return __binary_search::binary_search(
-            policy, first, last, values_first, values_last, result, compare_op
-        );
-        #endif
-      }
-
-
-      __device__
-      static OutputIt seq(execution_policy<Derived>& policy,
-                          HaystackIt                 first,
-                          HaystackIt                 last,
-                          NeedlesIt                  values_first,
-                          NeedlesIt                  values_last,
-                          OutputIt                   result,
-                          CompareOp                  compare_op)
-      {
-        return thrust::binary_search(cvt_to_seq(derived_cast(policy)),
-                                   first,
-                                   last,
-                                   values_first,
-                                   values_last,
-                                   result,
-                                   compare_op);
-      }
+        __device__ static OutputIt seq(execution_policy<Derived>& policy,
+                                       HaystackIt                 first,
+                                       HaystackIt                 last,
+                                       NeedlesIt                  values_first,
+                                       NeedlesIt                  values_last,
+                                       OutputIt                   result,
+                                       CompareOp                  compare_op)
+        {
+            return thrust::binary_search(cvt_to_seq(derived_cast(policy)),
+                                         first,
+                                         last,
+                                         values_first,
+                                         values_last,
+                                         result,
+                                         compare_op);
+        }
   };
 
   #if __THRUST_HAS_HIPRT__
@@ -492,6 +451,7 @@ HaystackIt lower_bound(execution_policy<Derived>& policy,
     using values_type = typename thrust::detail::temporary_array<T, Derived>;
     using results_type = typename thrust::detail::temporary_array<difference_type, Derived>;
 
+    // struct workaround is required for HIP-clang
     struct workaround
     {
         __host__
@@ -501,29 +461,16 @@ HaystackIt lower_bound(execution_policy<Derived>& policy,
                               const T&                   value,
                               CompareOp                  compare_op)
         {
-          #if __HCC__ && __HIP_DEVICE_COMPILE__
-            THRUST_HIP_PRESERVE_KERNELS_WORKAROUND
-            (__binary_search::lower_bound<Derived,
-                                          HaystackIt,
-                                          typename values_type::iterator,
-                                          typename results_type::iterator,
-                                          CompareOp>);
-            return first;
-          #else
-          values_type values(policy, 1);
-          results_type result(policy, 1);
+            values_type  values(policy, 1);
+            results_type result(policy, 1);
 
-          values[0] = value;
+            values[0] = value;
 
-          __binary_search::lower_bound(
-              policy, first, last, values.begin(), values.end(), result.begin(), compare_op
-          );
+            __binary_search::lower_bound(
+                policy, first, last, values.begin(), values.end(), result.begin(), compare_op);
 
-          return first + result[0];
-
-          #endif
+            return first + result[0];
         }
-
 
         __device__
         static HaystackIt seq(execution_policy<Derived>& policy,
@@ -564,6 +511,7 @@ HaystackIt upper_bound(execution_policy<Derived>& policy,
     using values_type = typename thrust::detail::temporary_array<T, Derived>;
     using results_type = typename thrust::detail::temporary_array<difference_type, Derived>;
 
+    // struct workaround is required for HIP-clang
     struct workaround
     {
         __host__
@@ -573,16 +521,6 @@ HaystackIt upper_bound(execution_policy<Derived>& policy,
                               const T&                   value,
                               CompareOp                  compare_op)
         {
-          #if __HCC__ && __HIP_DEVICE_COMPILE__
-            THRUST_HIP_PRESERVE_KERNELS_WORKAROUND
-            (__binary_search::upper_bound<Derived,
-                                          HaystackIt,
-                                          typename values_type::iterator,
-                                          typename results_type::iterator,
-                                          CompareOp>);
-            return first;
-
-          #else
           values_type values(policy, 1);
           results_type result(policy, 1);
 
@@ -593,10 +531,7 @@ HaystackIt upper_bound(execution_policy<Derived>& policy,
           );
 
           return first + result[0];
-
-          #endif
         }
-
 
         __device__
         static HaystackIt seq(execution_policy<Derived>& policy,
@@ -635,6 +570,7 @@ bool binary_search(execution_policy<Derived>& policy,
     using values_type = typename thrust::detail::temporary_array<T, Derived>;
     using results_type = typename thrust::detail::temporary_array<int, Derived>;
 
+    // struct workaround is required for HIP-clang
     struct workaround
     {
         __host__
@@ -644,15 +580,6 @@ bool binary_search(execution_policy<Derived>& policy,
                               const T&                   value,
                               CompareOp                  compare_op)
         {
-          #if __HCC__ && __HIP_DEVICE_COMPILE__
-            THRUST_HIP_PRESERVE_KERNELS_WORKAROUND
-            (__binary_search::binary_search<Derived,
-                                          HaystackIt,
-                                          typename values_type::iterator,
-                                          typename results_type::iterator,
-                                          CompareOp>);
-            return first;
-          #else
           values_type values(policy, 1);
           results_type result(policy, 1);
 
@@ -663,9 +590,7 @@ bool binary_search(execution_policy<Derived>& policy,
           );
 
           return result[0] != 0;
-          #endif
         }
-
 
         __device__
         static bool seq(execution_policy<Derived>& policy,

--- a/thrust/system/hip/detail/copy.h
+++ b/thrust/system/hip/detail/copy.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -86,8 +86,7 @@ THRUST_NAMESPACE_END
 #include <thrust/system/hip/detail/internal/copy_device_to_device.h>
 #include <thrust/system/hip/detail/par_to_seq.h>
 
-namespace thrust
-{
+THRUST_NAMESPACE_BEGIN
 namespace hip_rocprim
 {
 

--- a/thrust/system/hip/detail/copy.h
+++ b/thrust/system/hip/detail/copy.h
@@ -50,7 +50,7 @@ OutputIt copy_n(const thrust::detail::execution_policy_base<DerivedPolicy>& exec
 namespace hip_rocprim
 {
 
-// D->D copy requires HCC compiler
+// D->D copy requires HIP compiler
 template <class System, class InputIterator, class OutputIterator>
 OutputIterator THRUST_HIP_FUNCTION
 copy(execution_policy<System>& system,
@@ -59,11 +59,10 @@ copy(execution_policy<System>& system,
      OutputIterator            result);
 
 template <class System1, class System2, class InputIterator, class OutputIterator>
-OutputIterator __host__ /* WORKAROUND */ __device__
-copy(cross_system<System1, System2> systems,
-     InputIterator                  first,
-     InputIterator                  last,
-     OutputIterator                 result);
+OutputIterator THRUST_HIP_FUNCTION copy(cross_system<System1, System2> systems,
+                                        InputIterator                  first,
+                                        InputIterator                  last,
+                                        OutputIterator                 result);
 
 template <class System, class InputIterator, class Size, class OutputIterator>
 OutputIterator THRUST_HIP_FUNCTION
@@ -73,11 +72,8 @@ copy_n(execution_policy<System>& system,
        OutputIterator            result);
 
 template <class System1, class System2, class InputIterator, class Size, class OutputIterator>
-OutputIterator __host__ /* WORKAROUND */ __device__
-copy_n(cross_system<System1, System2> systems,
-       InputIterator                  first,
-       Size                           n,
-       OutputIterator                 result);
+OutputIterator THRUST_HIP_FUNCTION
+copy_n(cross_system<System1, System2> systems, InputIterator first, Size n, OutputIterator result);
 
 } // namespace hip_rocprim
 THRUST_NAMESPACE_END
@@ -91,7 +87,7 @@ namespace hip_rocprim
 {
 
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_HIP
-// D->D copy requires HCC compiler
+// D->D copy requires HIP compiler
 
 __thrust_exec_check_disable__ template <class System, class InputIterator, class OutputIterator>
 OutputIterator THRUST_HIP_FUNCTION
@@ -100,34 +96,23 @@ copy(execution_policy<System>& system,
      InputIterator             last,
      OutputIterator            result)
 {
-  // struct workaround is required for HIP-clang
-  // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
-  struct workaround
-  {
-      __host__
-      static OutputIterator par(
-          execution_policy<System>& system,
-          InputIterator             first,
-          InputIterator             last,
-          OutputIterator            result)
-      {
-      #if __HCC__ && __HIP_DEVICE_COMPILE__
-      THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-          (__copy::device_to_device<System, InputIterator, OutputIterator>)
-      );
-      #else
-      return __copy::device_to_device(system, first, last, result);
-      #endif
-      }
-      __device__
-      static OutputIterator seq(
-          execution_policy<System>& system,
-          InputIterator             first,
-          InputIterator             last,
-          OutputIterator            result)
-      {
-          return thrust::copy(cvt_to_seq(derived_cast(system)), first, last, result);
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIterator par(execution_policy<System>& system,
+                                           InputIterator             first,
+                                           InputIterator             last,
+                                           OutputIterator            result)
+        {
+            return __copy::device_to_device(system, first, last, result);
+        }
+        __device__ static OutputIterator seq(execution_policy<System>& system,
+                                             InputIterator             first,
+                                             InputIterator             last,
+                                             OutputIterator            result)
+        {
+            return thrust::copy(cvt_to_seq(derived_cast(system)), first, last, result);
+        }
   };
 
 #if __THRUST_HAS_HIPRT__
@@ -147,34 +132,19 @@ copy_n(execution_policy<System>& system,
        Size                      n,
        OutputIterator            result)
 {
-  // struct workaround is required for HIP-clang
-  // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
-  struct workaround
-  {
-      __host__
-      static OutputIterator par(
-          execution_policy<System>& system,
-          InputIterator             first,
-          Size                      n,
-          OutputIterator            result)
-      {
-      #if __HCC__ && __HIP_DEVICE_COMPILE__
-      THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-          (__copy::device_to_device<System, InputIterator, OutputIterator>)
-      );
-      #else
-      return __copy::device_to_device(system, first, first + n, result);
-      #endif
-      }
-      __device__
-      static OutputIterator seq(
-          execution_policy<System>& system,
-          InputIterator             first,
-          Size                      n,
-          OutputIterator            result)
-      {
-          return thrust::copy_n(cvt_to_seq(derived_cast(system)), first, n, result);
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIterator
+        par(execution_policy<System>& system, InputIterator first, Size n, OutputIterator result)
+        {
+            return __copy::device_to_device(system, first, first + n, result);
+        }
+        __device__ static OutputIterator
+        seq(execution_policy<System>& system, InputIterator first, Size n, OutputIterator result)
+        {
+            return thrust::copy_n(cvt_to_seq(derived_cast(system)), first, n, result);
+        }
   };
   #if __THRUST_HAS_HIPRT__
       return workaround::par(system, first, n, result);
@@ -185,21 +155,17 @@ copy_n(execution_policy<System>& system,
 #endif
 
 template <class System1, class System2, class InputIterator, class OutputIterator>
-OutputIterator __host__ /* WORKAROUND */ __device__
-copy(cross_system<System1, System2> systems,
-     InputIterator                  first,
-     InputIterator                  last,
-     OutputIterator                 result)
+OutputIterator THRUST_HIP_FUNCTION copy(cross_system<System1, System2> systems,
+                                        InputIterator                  first,
+                                        InputIterator                  last,
+                                        OutputIterator                 result)
 {
     return __copy::cross_system_copy(systems, first, last, result);
 } // end copy()
 
 template <class System1, class System2, class InputIterator, class Size, class OutputIterator>
-OutputIterator __host__ /* WORKAROUND */ __device__
-copy_n(cross_system<System1, System2> systems,
-       InputIterator                  first,
-       Size                           n,
-       OutputIterator                 result)
+OutputIterator THRUST_HIP_FUNCTION
+copy_n(cross_system<System1, System2> systems, InputIterator first, Size n, OutputIterator result)
 {
     return __copy::cross_system_copy_n(systems, first, n, result);
 } // end copy_n()

--- a/thrust/system/hip/detail/copy_if.h
+++ b/thrust/system/hip/detail/copy_if.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -44,7 +44,7 @@
 THRUST_NAMESPACE_BEGIN
 
 // XXX declare generic copy_if interface
-// to avoid circulular dependency from thrust/copy.h
+// to avoid circular dependency from thrust/copy.h
 template <typename DerivedPolicy,
           typename InputIterator,
           typename OutputIterator,
@@ -198,46 +198,25 @@ copy_if(execution_policy<Derived>& policy,
         OutputIterator             result,
         Predicate                  pred)
 {
-  // struct workaround is required for HIP-clang
-  // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
-  struct workaround
-  {
-      __host__
-      static OutputIterator par(execution_policy<Derived>& policy,
-                      InputIterator              first,
-                      InputIterator              last,
-                      OutputIterator             result,
-                      Predicate                  pred)
-      {
-      #if __HCC__ && __HIP_DEVICE_COMPILE__
-      THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-          (__copy_if::copy_if<Derived, InputIterator, OutputIterator, Predicate>)
-      );
-      #else
-      return __copy_if::copy_if(
-          policy,
-          first,
-          last,
-          result,
-          pred
-      );
-      #endif
-      }
-      __device__
-      static OutputIterator seq(execution_policy<Derived>& policy,
-                      InputIterator              first,
-                      InputIterator              last,
-                      OutputIterator             result,
-                      Predicate                  pred)
-      {
-          return thrust::copy_if(
-             cvt_to_seq(derived_cast(policy)),
-             first,
-             last,
-             result,
-             pred
-          );
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIterator par(execution_policy<Derived>& policy,
+                                           InputIterator              first,
+                                           InputIterator              last,
+                                           OutputIterator             result,
+                                           Predicate                  pred)
+        {
+            return __copy_if::copy_if(policy, first, last, result, pred);
+        }
+        __device__ static OutputIterator seq(execution_policy<Derived>& policy,
+                                             InputIterator              first,
+                                             InputIterator              last,
+                                             OutputIterator             result,
+                                             Predicate                  pred)
+        {
+            return thrust::copy_if(cvt_to_seq(derived_cast(policy)), first, last, result, pred);
+        }
   };
 
   #if __THRUST_HAS_HIPRT__
@@ -264,56 +243,28 @@ copy_if(execution_policy<Derived>& policy,
         Predicate                  pred)
 {
 
-  // struct workaround is required for HIP-clang
-  // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
-  struct workaround
-  {
-      __host__
-      static OutputIterator par(
-        execution_policy<Derived>& policy,
-        InputIterator              first,
-        InputIterator              last,
-        StencilIterator            stencil,
-        OutputIterator             result,
-        Predicate                  pred)
-      {
-      #if __HCC__ && __HIP_DEVICE_COMPILE__
-      THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-          (__copy_if::copy_if<Derived,
-                             InputIterator,
-                             StencilIterator,
-                             OutputIterator,
-                             Predicate>)
-      );
-      #else
-      return __copy_if::copy_if(
-          policy,
-          first,
-          last,
-          stencil,
-          result,
-          pred
-      );
-      #endif
-      }
-      __device__
-      static OutputIterator seq(
-        execution_policy<Derived>& policy,
-        InputIterator              first,
-        InputIterator              last,
-        StencilIterator            stencil,
-        OutputIterator             result,
-        Predicate                  pred)
-      {
-          return thrust::copy_if(
-             cvt_to_seq(derived_cast(policy)),
-             first,
-             last,
-             stencil,
-             result,
-             pred
-          );
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIterator par(execution_policy<Derived>& policy,
+                                           InputIterator              first,
+                                           InputIterator              last,
+                                           StencilIterator            stencil,
+                                           OutputIterator             result,
+                                           Predicate                  pred)
+        {
+            return __copy_if::copy_if(policy, first, last, stencil, result, pred);
+        }
+        __device__ static OutputIterator seq(execution_policy<Derived>& policy,
+                                             InputIterator              first,
+                                             InputIterator              last,
+                                             StencilIterator            stencil,
+                                             OutputIterator             result,
+                                             Predicate                  pred)
+        {
+            return thrust::copy_if(
+                cvt_to_seq(derived_cast(policy)), first, last, stencil, result, pred);
+        }
   };
 
 #if __THRUST_HAS_HIPRT__

--- a/thrust/system/hip/detail/cross_system.h
+++ b/thrust/system/hip/detail/cross_system.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -54,8 +54,6 @@ struct cross_system : execution_policy<cross_system<Sys1, Sys2> >
     }
 };
 
-
-#if THRUST_CPP_DIALECT >= 2011
   // Device to host.
   template <class Sys1, class Sys2>
   constexpr __host__ __device__
@@ -220,109 +218,82 @@ struct cross_system : execution_policy<cross_system<Sys1, Sys2> >
 
   // Device to host.
   template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_device_system(thrust::hip::execution_policy<Sys1> &sys1,
-                       thrust::execution_policy<Sys2> &)
-  THRUST_DECLTYPE_RETURNS(sys1)
+  __host__ __device__ auto select_device_system(thrust::hip::execution_policy<Sys1>& sys1,
+                                                thrust::execution_policy<Sys2>&)
+      THRUST_DECLTYPE_RETURNS(sys1)
 
-  // Device to host.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_device_system(thrust::hip::execution_policy<Sys1> const &sys1,
-                       thrust::execution_policy<Sys2> const &)
-  THRUST_DECLTYPE_RETURNS(sys1)
+      // Device to host.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_device_system(thrust::hip::execution_policy<Sys1> const& sys1,
+                                                    thrust::execution_policy<Sys2> const&)
+          THRUST_DECLTYPE_RETURNS(sys1)
 
-  // Host to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_device_system(thrust::execution_policy<Sys1> &,
-                       thrust::hip::execution_policy<Sys2> &sys2)
-  THRUST_DECLTYPE_RETURNS(sys2)
+      // Host to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_device_system(thrust::execution_policy<Sys1>&,
+                                                    thrust::hip::execution_policy<Sys2>& sys2)
+          THRUST_DECLTYPE_RETURNS(sys2)
 
-  // Host to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_device_system(thrust::execution_policy<Sys1> const &,
-                       thrust::hip::execution_policy<Sys2> const &sys2)
-  THRUST_DECLTYPE_RETURNS(sys2)
+      // Host to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_device_system(thrust::execution_policy<Sys1> const&,
+                                                    thrust::hip::execution_policy<Sys2> const& sys2)
+          THRUST_DECLTYPE_RETURNS(sys2)
 
-  // Device to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_device_system(thrust::hip::execution_policy<Sys1> &sys1,
-                       thrust::hip::execution_policy<Sys2> &)
-  THRUST_DECLTYPE_RETURNS(sys1)
+      // Device to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_device_system(thrust::hip::execution_policy<Sys1>& sys1,
+                                                    thrust::hip::execution_policy<Sys2>&)
+          THRUST_DECLTYPE_RETURNS(sys1)
 
-  // Device to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_device_system(thrust::hip::execution_policy<Sys1> const &sys1,
-                       thrust::hip::execution_policy<Sys2> const &)
-  THRUST_DECLTYPE_RETURNS(sys1)
+      // Device to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_device_system(thrust::hip::execution_policy<Sys1> const& sys1,
+                                                    thrust::hip::execution_policy<Sys2> const&)
+          THRUST_DECLTYPE_RETURNS(sys1)
 
-  /////////////////////////////////////////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////
 
-  // Device to host.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_host_system(thrust::hip::execution_policy<Sys1> &,
-                     thrust::execution_policy<Sys2> &sys2)
-  THRUST_DECLTYPE_RETURNS(sys2)
+      // Device to host.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_host_system(thrust::hip::execution_policy<Sys1>&,
+                                                  thrust::execution_policy<Sys2>& sys2)
+          THRUST_DECLTYPE_RETURNS(sys2)
 
-  // Device to host.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_host_system(thrust::hip::execution_policy<Sys1> const &,
-                     thrust::execution_policy<Sys2> const &sys2)
-  THRUST_DECLTYPE_RETURNS(sys2)
+      // Device to host.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_host_system(thrust::hip::execution_policy<Sys1> const&,
+                                                  thrust::execution_policy<Sys2> const& sys2)
+          THRUST_DECLTYPE_RETURNS(sys2)
 
-  // Host to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_host_system(thrust::execution_policy<Sys1> &sys1,
-                     thrust::hip::execution_policy<Sys2> &)
-  THRUST_DECLTYPE_RETURNS(sys1)
+      // Host to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_host_system(thrust::execution_policy<Sys1>& sys1,
+                                                  thrust::hip::execution_policy<Sys2>&)
+          THRUST_DECLTYPE_RETURNS(sys1)
 
-  // Host to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_host_system(thrust::execution_policy<Sys1> const &sys1,
-                     thrust::hip::execution_policy<Sys2> const &)
-  THRUST_DECLTYPE_RETURNS(sys1)
+      // Host to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_host_system(thrust::execution_policy<Sys1> const& sys1,
+                                                  thrust::hip::execution_policy<Sys2> const&)
+          THRUST_DECLTYPE_RETURNS(sys1)
 
-  // Device to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_host_system(thrust::execution_policy<Sys1> &sys1,
-                     thrust::execution_policy<Sys2> &)
-  THRUST_DECLTYPE_RETURNS(sys1)
+      // Device to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__
+      auto select_host_system(thrust::execution_policy<Sys1>& sys1, thrust::execution_policy<Sys2>&)
+          THRUST_DECLTYPE_RETURNS(sys1)
 
-  // Device to device.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  auto
-  select_host_system(thrust::execution_policy<Sys1> const &sys1,
-                     thrust::execution_policy<Sys2> const &)
-  THRUST_DECLTYPE_RETURNS(sys1)
-#endif
+      // Device to device.
+      template <class Sys1, class Sys2>
+      __host__ __device__ auto select_host_system(thrust::execution_policy<Sys1> const& sys1,
+                                                  thrust::execution_policy<Sys2> const&)
+          THRUST_DECLTYPE_RETURNS(sys1)
 
-  // Device to host.
-  template <class Sys1, class Sys2>
-  __host__ __device__
-  cross_system<Sys1, Sys2>
-  select_system(execution_policy<Sys1> const &             sys1,
-                thrust::cpp::execution_policy<Sys2> const &sys2)
+      // Device to host.
+      template <class Sys1, class Sys2>
+      __host__ __device__ cross_system<Sys1, Sys2> select_system(
+          execution_policy<Sys1> const& sys1, thrust::cpp::execution_policy<Sys2> const& sys2)
   {
     thrust::execution_policy<Sys1> &     non_const_sys1 = const_cast<execution_policy<Sys1> &>(sys1);
     thrust::cpp::execution_policy<Sys2> &non_const_sys2 = const_cast<thrust::cpp::execution_policy<Sys2> &>(sys2);

--- a/thrust/system/hip/detail/execution_policy.h
+++ b/thrust/system/hip/detail/execution_policy.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -31,14 +31,11 @@
 
 #include <hip/hip_runtime.h>
 
+#include <thrust/detail/allocator_aware_execution_policy.h>
+#include <thrust/detail/dependencies_aware_execution_policy.h>
 #include <thrust/detail/execution_policy.h>
 #include <thrust/iterator/detail/any_system_tag.h>
 #include <thrust/system/hip/config.h>
-#include <thrust/detail/allocator_aware_execution_policy.h>
-
-#if THRUST_CPP_DIALECT >= 2011
-  #include <thrust/detail/dependencies_aware_execution_policy.h>
-#endif
 
 THRUST_NAMESPACE_BEGIN
 
@@ -55,11 +52,9 @@ namespace hip_rocprim
         typedef tag tag_type;
     };
 
-    struct tag : execution_policy<tag>
-    , thrust::detail::allocator_aware_execution_policy<hip_rocprim::execution_policy>
-    #if THRUST_CPP_DIALECT >= 2011
-    , thrust::detail::dependencies_aware_execution_policy<hip_rocprim::execution_policy>
-    #endif
+    struct tag : execution_policy<tag>,
+                 thrust::detail::allocator_aware_execution_policy<hip_rocprim::execution_policy>,
+                 thrust::detail::dependencies_aware_execution_policy<hip_rocprim::execution_policy>
     {};
 
     template <class Derived>

--- a/thrust/system/hip/detail/guarded_driver_types.h
+++ b/thrust/system/hip/detail/guarded_driver_types.h
@@ -22,40 +22,26 @@
 // the purpose of this header is to #include <driver_types.h> without causing
 // warnings from redefinitions of __host__ and __device__.
 // carefully save their definitions and restore them
-// can't tell exactly when push_macro & pop_macro were introduced to gcc; assume 4.5.0
 
 
-#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40500)
-#  ifdef __host__
-#    pragma push_macro("__host__")
-#    undef __host__
-#    define THRUST_HOST_NEEDS_RESTORATION
-#  endif
-#  ifdef __device__
-#    pragma push_macro("__device__")
-#    undef __device__
-#    define THRUST_DEVICE_NEEDS_RESTORATION
-#  endif
-#else // GNUC pre 4.5.0
-#  if !defined(__HIP_PLATFORM_AMD__)
-#    ifdef __host__
-#      undef __host__
-#    endif
-#    ifdef __device__
-#      undef __device__
-#    endif
-#  endif // __DRIVER_TYPES_H__
-#endif // __GNUC__
+#ifdef __host__
+#  pragma push_macro("__host__")
+#  undef __host__
+#  define THRUST_HOST_NEEDS_RESTORATION
+#endif
+#ifdef __device__
+#  pragma push_macro("__device__")
+#  undef __device__
+#  define THRUST_DEVICE_NEEDS_RESTORATION
+#endif
 
 #include <hip/amd_detail/host_defines.h>
 
-#if !defined(__GNUC__) || ((10000 * __GNUC__ + 100 * __GNUC_MINOR__ + __GNUC_PATCHLEVEL__) >= 40500)
-#  ifdef THRUST_HOST_NEEDS_RESTORATION
-#    pragma pop_macro("__host__")
-#    undef THRUST_HOST_NEEDS_RESTORATION
-#  endif
-#  ifdef THRUST_DEVICE_NEEDS_RESTORATION
-#    pragma pop_macro("__device__")
-#    undef THRUST_DEVICE_NEEDS_RESTORATION
-#  endif
-#endif // __GNUC__
+#ifdef THRUST_HOST_NEEDS_RESTORATION
+#  pragma pop_macro("__host__")
+#  undef THRUST_HOST_NEEDS_RESTORATION
+#endif
+#ifdef THRUST_DEVICE_NEEDS_RESTORATION
+#  pragma pop_macro("__device__")
+#  undef THRUST_DEVICE_NEEDS_RESTORATION
+#endif

--- a/thrust/system/hip/detail/memory.inl
+++ b/thrust/system/hip/detail/memory.inl
@@ -21,8 +21,7 @@
 #include <thrust/system/hip/detail/malloc_and_free.h>
 #include <limits>
 
-namespace thrust
-{
+THRUST_NAMESPACE_BEGIN
 namespace hip_rocprim
 {
 
@@ -46,4 +45,4 @@ THRUST_HIP_FUNCTION void free(pointer<void> ptr)
 } // end free()
 
 } // end hip_rocprim
-} // end thrust
+THRUST_NAMESPACE_END

--- a/thrust/system/hip/detail/par.h
+++ b/thrust/system/hip/detail/par.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019-2022, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -27,18 +27,12 @@
  ******************************************************************************/
 #pragma once
 
-
-#include <thrust/detail/config.h>
-#include <thrust/system/hip/detail/guarded_hip_runtime_api.h>
-#include <thrust/system/hip/detail/execution_policy.h>
-#include <thrust/system/hip/detail/util.h>
-
 #include <thrust/detail/allocator_aware_execution_policy.h>
-
-#if THRUST_CPP_DIALECT >= 2011
-#  include <thrust/detail/dependencies_aware_execution_policy.h>
-#endif
-
+#include <thrust/detail/config.h>
+#include <thrust/detail/dependencies_aware_execution_policy.h>
+#include <thrust/system/hip/detail/execution_policy.h>
+#include <thrust/system/hip/detail/guarded_hip_runtime_api.h>
+#include <thrust/system/hip/detail/util.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace hip_rocprim
@@ -131,10 +125,8 @@ namespace hip_rocprim
     };
 
     struct par_t : execution_policy<par_t>,
-        thrust::detail::allocator_aware_execution_policy<execute_on_stream_base>
-    #if THRUST_CPP_DIALECT >= 2011
-        , thrust::detail::dependencies_aware_execution_policy<execute_on_stream_base>
-    #endif
+                   thrust::detail::allocator_aware_execution_policy<execute_on_stream_base>,
+                   thrust::detail::dependencies_aware_execution_policy<execute_on_stream_base>
     {
         typedef execution_policy<par_t> base_t;
 
@@ -153,11 +145,10 @@ namespace hip_rocprim
         }
     };
 
-    struct par_nosync_t : execution_policy<par_nosync_t>,
-        thrust::detail::allocator_aware_execution_policy<execute_on_stream_nosync_base>
-    #if THRUST_CPP_DIALECT >= 2011
-        , thrust::detail::dependencies_aware_execution_policy<execute_on_stream_nosync_base>
-    #endif
+    struct par_nosync_t
+        : execution_policy<par_nosync_t>,
+          thrust::detail::allocator_aware_execution_policy<execute_on_stream_nosync_base>,
+          thrust::detail::dependencies_aware_execution_policy<execute_on_stream_nosync_base>
     {
         typedef execution_policy<par_nosync_t> base_t;
 

--- a/thrust/system/hip/detail/per_device_resource.h
+++ b/thrust/system/hip/detail/per_device_resource.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2020, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2020-2023, Advanced Micro Devices, Inc.  All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -28,9 +28,6 @@
 #pragma once
 
 #include <thrust/detail/config.h>
-#include <thrust/detail/cpp11_required.h>
-
-#if THRUST_CPP_DIALECT >= 2011
 
 #if THRUST_DEVICE_COMPILER == THRUST_DEVICE_COMPILER_HIP
 
@@ -63,7 +60,5 @@ MR * get_per_device_resource(execution_policy<DerivedPolicy>&)
 }
 
 THRUST_NAMESPACE_END
-
-#endif
 
 #endif

--- a/thrust/system/hip/detail/scan_by_key.h
+++ b/thrust/system/hip/detail/scan_by_key.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2019, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2019-2023, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -202,37 +202,37 @@ inclusive_scan_by_key(execution_policy<Derived>& policy,
                       BinaryPred                 binary_pred,
                       ScanOp                     scan_op)
 {
-  struct workaround
-  {
-      __host__
-      static ValOutputIt par(execution_policy<Derived>& policy,
-                          KeyInputIt                 key_first,
-                          KeyInputIt                 key_last,
-                          ValInputIt                 value_first,
-                          ValOutputIt                value_result,
-                          BinaryPred                 binary_pred,
-                          ScanOp                     scan_op)
-      {
-        #if __HCC__ && __HIP_DEVICE_COMPILE__
-        THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-               (__scan_by_key::inclusive_scan_by_key<Derived,KeyInputIt,ValInputIt,ValOutputIt,BinaryPred,ScanOp>)
-        );
-        #else
-        return __scan_by_key::inclusive_scan_by_key(policy,key_first, key_last, value_first, value_result, binary_pred, scan_op);
-        #endif
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static ValOutputIt par(execution_policy<Derived>& policy,
+                                        KeyInputIt                 key_first,
+                                        KeyInputIt                 key_last,
+                                        ValInputIt                 value_first,
+                                        ValOutputIt                value_result,
+                                        BinaryPred                 binary_pred,
+                                        ScanOp                     scan_op)
+        {
+            return __scan_by_key::inclusive_scan_by_key(
+                policy, key_first, key_last, value_first, value_result, binary_pred, scan_op);
+        }
 
-      __device__
-      static ValOutputIt seq(execution_policy<Derived>& policy,
-                          KeyInputIt                 key_first,
-                          KeyInputIt                 key_last,
-                          ValInputIt                 value_first,
-                          ValOutputIt                value_result,
-                          BinaryPred                 binary_pred,
-                          ScanOp                     scan_op)
-      {
-        return thrust::inclusive_scan_by_key( cvt_to_seq(derived_cast(policy)), key_first, key_last, value_first, value_result, binary_pred, scan_op);
-      }
+        __device__ static ValOutputIt seq(execution_policy<Derived>& policy,
+                                          KeyInputIt                 key_first,
+                                          KeyInputIt                 key_last,
+                                          ValInputIt                 value_first,
+                                          ValOutputIt                value_result,
+                                          BinaryPred                 binary_pred,
+                                          ScanOp                     scan_op)
+        {
+            return thrust::inclusive_scan_by_key(cvt_to_seq(derived_cast(policy)),
+                                                 key_first,
+                                                 key_last,
+                                                 value_first,
+                                                 value_result,
+                                                 binary_pred,
+                                                 scan_op);
+        }
   };
 
   #if __THRUST_HAS_HIPRT__
@@ -305,39 +305,40 @@ exclusive_scan_by_key(execution_policy<Derived>& policy,
                       ScanOp                     scan_op)
 {
 
-  struct workaround
-  {
-      __host__
-      static ValOutputIt par(execution_policy<Derived>& policy,
-                            KeyInputIt                 key_first,
-                            KeyInputIt                 key_last,
-                            ValInputIt                 value_first,
-                            ValOutputIt                value_result,
-                            Init                       init,
-                            BinaryPred                 binary_pred,
-                            ScanOp                     scan_op)
-      {
-        #if __HCC__ && __HIP_DEVICE_COMPILE__
-        THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-               (__scan_by_key::inclusive_scan_by_key<Derived,KeyInputIt,ValInputIt,ValOutputIt,Init,BinaryPred,ScanOp>)
-        );
-        #else
-        return __scan_by_key::exclusive_scan_by_key(policy,key_first, key_last, value_first, value_result, init, binary_pred, scan_op);
-        #endif
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static ValOutputIt par(execution_policy<Derived>& policy,
+                                        KeyInputIt                 key_first,
+                                        KeyInputIt                 key_last,
+                                        ValInputIt                 value_first,
+                                        ValOutputIt                value_result,
+                                        Init                       init,
+                                        BinaryPred                 binary_pred,
+                                        ScanOp                     scan_op)
+        {
+            return __scan_by_key::exclusive_scan_by_key(
+                policy, key_first, key_last, value_first, value_result, init, binary_pred, scan_op);
+        }
 
-      __device__
-      static ValOutputIt seq(execution_policy<Derived>& policy,
-                            KeyInputIt                 key_first,
-                            KeyInputIt                 key_last,
-                            ValInputIt                 value_first,
-                            ValOutputIt                value_result,
-                            Init                       init,
-                            BinaryPred                 binary_pred,
-                            ScanOp                     scan_op)
-      {
-        return thrust::exclusive_scan_by_key( cvt_to_seq(derived_cast(policy)), key_first, key_last, value_first, value_result, init, binary_pred, scan_op);
-      }
+        __device__ static ValOutputIt seq(execution_policy<Derived>& policy,
+                                          KeyInputIt                 key_first,
+                                          KeyInputIt                 key_last,
+                                          ValInputIt                 value_first,
+                                          ValOutputIt                value_result,
+                                          Init                       init,
+                                          BinaryPred                 binary_pred,
+                                          ScanOp                     scan_op)
+        {
+            return thrust::exclusive_scan_by_key(cvt_to_seq(derived_cast(policy)),
+                                                 key_first,
+                                                 key_last,
+                                                 value_first,
+                                                 value_result,
+                                                 init,
+                                                 binary_pred,
+                                                 scan_op);
+        }
   };
 
   #if __THRUST_HAS_HIPRT__

--- a/thrust/system/hip/detail/sort.h
+++ b/thrust/system/hip/detail/sort.h
@@ -395,7 +395,6 @@ stable_sort(execution_policy<Derived>& policy,
             CompareOp                  compare_op)
 {
     // struct workaround is required for HIP-clang
-    // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
     struct workaround
     {
         __host__
@@ -404,16 +403,9 @@ stable_sort(execution_policy<Derived>& policy,
                         ItemsIt                    last,
                         CompareOp                  compare_op)
         {
-        #if __HCC__ && __HIP_DEVICE_COMPILE__
-        THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-            (__smart_sort::smart_sort<detail::false_type, Derived, ItemsIt, ItemsIt, CompareOp>)
-        );
-        #else
-        typedef typename thrust::iterator_value<ItemsIt>::type item_type;
-        __smart_sort::smart_sort<detail::false_type>(
-                                 policy, first, last, (item_type*)NULL, compare_op
-                                 );
-        #endif
+            typedef typename thrust::iterator_value<ItemsIt>::type item_type;
+            __smart_sort::smart_sort<detail::false_type>(
+                policy, first, last, (item_type*)NULL, compare_op);
         }
         __device__
         static void seq(execution_policy<Derived>& policy,
@@ -453,7 +445,6 @@ stable_sort_by_key(execution_policy<Derived>& policy,
                    CompareOp                  compare_op)
 {
     // struct workaround is required for HIP-clang
-    // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
     struct workaround
     {
         __host__
@@ -463,14 +454,8 @@ stable_sort_by_key(execution_policy<Derived>& policy,
                         ValuesIt                   values,
                         CompareOp                  compare_op)
         {
-            #if __HCC__ && __HIP_DEVICE_COMPILE__
-             THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-                   (__smart_sort::smart_sort<detail::true_type, Derived, KeysIt, ValuesIt, CompareOp>)
-               );
-             #else
             __smart_sort::smart_sort<detail::true_type>(
-                            policy, keys_first, keys_last, values, compare_op);
-            #endif
+                policy, keys_first, keys_last, values, compare_op);
         }
 
         __device__

--- a/thrust/system/hip/detail/terminate.h
+++ b/thrust/system/hip/detail/terminate.h
@@ -33,8 +33,7 @@
 
 #include <cstdio>
 
-namespace thrust
-{
+THRUST_NAMESPACE_BEGIN
 namespace system
 {
 namespace hip
@@ -59,4 +58,4 @@ void THRUST_HIP_FUNCTION terminate_with_message(const char* message)
 } // end detail
 } // end hip
 } // end system
-} // end thrust
+THRUST_NAMESPACE_END

--- a/thrust/system/hip/detail/unique.h
+++ b/thrust/system/hip/detail/unique.h
@@ -142,35 +142,26 @@ unique_copy(execution_policy<Derived>& policy,
             OutputIt                   result,
             BinaryPred                 binary_pred)
 {
-  // struct workaround is required for HIP-clang
-  // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
-  struct workaround
-  {
-      __host__
-      static OutputIt par(execution_policy<Derived>& policy,
-                   InputIt                    first,
-                   InputIt                    last,
-                   OutputIt                   result,
-                   BinaryPred                 binary_pred)
-      {
-      #if __HCC__ && __HIP_DEVICE_COMPILE__
-        THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(__unique::unique<Derived, InputIt, OutputIt, BinaryPred>);
-      #else
-        return __unique::unique(policy, first, last, result, binary_pred);
-      #endif
-      }
-      __device__
-      static OutputIt seq(execution_policy<Derived>& policy,
-                   InputIt                    first,
-                   InputIt                    last,
-                   OutputIt                   result,
-                   BinaryPred                 binary_pred)
-      {
-        return thrust::unique_copy
-            (
-                cvt_to_seq(derived_cast(policy)), first, last, result, binary_pred
-            );
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static OutputIt par(execution_policy<Derived>& policy,
+                                     InputIt                    first,
+                                     InputIt                    last,
+                                     OutputIt                   result,
+                                     BinaryPred                 binary_pred)
+        {
+            return __unique::unique(policy, first, last, result, binary_pred);
+        }
+        __device__ static OutputIt seq(execution_policy<Derived>& policy,
+                                       InputIt                    first,
+                                       InputIt                    last,
+                                       OutputIt                   result,
+                                       BinaryPred                 binary_pred)
+        {
+            return thrust::unique_copy(
+                cvt_to_seq(derived_cast(policy)), first, last, result, binary_pred);
+        }
   };
   #if __THRUST_HAS_HIPRT__
     return workaround::par(policy, first, last, result, binary_pred);
@@ -194,34 +185,19 @@ unique(execution_policy<Derived>& policy,
        InputIt                    last,
        BinaryPred                 binary_pred)
 {
-  // struct workaround is required for HIP-clang
-  // THRUST_HIP_PRESERVE_KERNELS_WORKAROUND is required for HCC
-  struct workaround
-  {
-      __host__
-      static InputIt par(execution_policy<Derived>& policy,
-                         InputIt                    first,
-                         InputIt                    last,
-                         BinaryPred                 binary_pred)
-      {
-      #if __HCC__ && __HIP_DEVICE_COMPILE__
-          THRUST_HIP_PRESERVE_KERNELS_WORKAROUND(
-              (unique_copy<Derived, InputIt, InputIt, BinaryPred>)
-          );
-      #else
-          return hip_rocprim::unique_copy(policy, first, last, first, binary_pred);
-      #endif
-      }
-      __device__
-      static InputIt seq(execution_policy<Derived>& policy,
-                         InputIt                    first,
-                         InputIt                    last,
-                         BinaryPred                 binary_pred)
-      {
-          return thrust::unique(
-              cvt_to_seq(derived_cast(policy)), first, last, binary_pred
-          );
-      }
+    // struct workaround is required for HIP-clang
+    struct workaround
+    {
+        __host__ static InputIt
+        par(execution_policy<Derived>& policy, InputIt first, InputIt last, BinaryPred binary_pred)
+        {
+            return hip_rocprim::unique_copy(policy, first, last, first, binary_pred);
+        }
+        __device__ static InputIt
+        seq(execution_policy<Derived>& policy, InputIt first, InputIt last, BinaryPred binary_pred)
+        {
+            return thrust::unique(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);
+        }
   };
   #if __THRUST_HAS_HIPRT__
       return workaround::par(policy, first, last, binary_pred);

--- a/thrust/system/hip/detail/util.h
+++ b/thrust/system/hip/detail/util.h
@@ -87,15 +87,13 @@ hipError_t synchronize_stream(execution_policy<Derived>& policy)
   hipError_t result;
 if (THRUST_IS_HOST_CODE) {
   #if THRUST_INCLUDE_HOST_CODE
-    hipStreamSynchronize(stream(policy));
-    result = hipGetLastError();
+    result = hipStreamSynchronize(stream(policy));
   #endif
 } else {
   #if THRUST_INCLUDE_DEVICE_CODE
     #if __THRUST_HAS_HIPRT__
       THRUST_UNUSED_VAR(policy);
-      hipDeviceSynchronize();
-      result = hipGetLastError();
+      result = hipDeviceSynchronize();
     #else
       THRUST_UNUSED_VAR(policy);
       result = hipSuccess;

--- a/thrust/system/hip/detail/util.h
+++ b/thrust/system/hip/detail/util.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2016, NVIDIA CORPORATION.  All rights meserved.
- *  Modifications Copyright© 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -316,18 +316,15 @@ struct transform_input_iterator_t
     {
     }
 
+    transform_input_iterator_t(const self_t&) = default;
 
-#if THRUST_CPP_DIALECT >= 2011
-  transform_input_iterator_t(const self_t &) = default;
-#endif
-
-  // UnaryOp might not be copy assignable, such as when it is a lambda.  Define
-  // an explicit copy assignment operator that doesn't try to assign it.
-  THRUST_HIP_FUNCTION self_t& operator=(const self_t& o)
-  {
-    input = o.input;
-    return *this;
-  }
+    // UnaryOp might not be copy assignable, such as when it is a lambda.  Define
+    // an explicit copy assignment operator that doesn't try to assign it.
+    THRUST_HIP_FUNCTION self_t& operator=(const self_t& o)
+    {
+        input = o.input;
+        return *this;
+    }
 
     /// Postfix increment
     THRUST_HIP_FUNCTION self_t operator++(int)
@@ -432,14 +429,12 @@ struct transform_pair_of_input_iterators_t
     {
     }
 
-    #if THRUST_CPP_DIALECT >= 2011
-      transform_pair_of_input_iterators_t(const self_t &) = default;
-    #endif
+    transform_pair_of_input_iterators_t(const self_t&) = default;
 
-      // BinaryOp might not be copy assignable, such as when it is a lambda.
-      // Define an explicit copy assignment operator that doesn't try to assign it.
-      self_t& operator=(const self_t& o)
-      {
+    // BinaryOp might not be copy assignable, such as when it is a lambda.
+    // Define an explicit copy assignment operator that doesn't try to assign it.
+    self_t& operator=(const self_t& o)
+    {
         input1 = o.input1;
         input2 = o.input2;
         return *this;

--- a/thrust/system/hip/memory_resource.h
+++ b/thrust/system/hip/memory_resource.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2018-2020 NVIDIA Corporation
- *  Modifications Copyright© 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -56,7 +56,9 @@ namespace detail
 
             if (status != hipSuccess)
             {
-                hipGetLastError(); // Clear the HIP global error state.
+                // Clear the HIP global error state.
+                hipError_t clear_error_status = hipGetLastError();
+                THRUST_UNUSED_VAR(clear_error_status);
                 throw thrust::system::detail::bad_alloc(thrust::hip_category().message(status).c_str());
             }
 

--- a/toolchain-linux.cmake
+++ b/toolchain-linux.cmake
@@ -14,29 +14,3 @@ endif()
 # set(CMAKE_C_COMPILER "hipcc")
 set(CMAKE_CXX_COMPILER "${rocm_bin}/hipcc")
 set(CMAKE_C_COMPILER "${rocm_bin}/hipcc")
-
-#set(CMAKE_CXX_LINKER "hipcc" )
-
-# TODO remove, just to speed up slow cmake
-# set(CMAKE_C_COMPILER_WORKS 1)
-# set(CMAKE_CXX_COMPILER_WORKS 1)
-#
-
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include -IC:/hip/lib/clang/12.0.0 -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
-
-# flags for clang direct use
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility")
-# -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
-
-# flags for clang direct use with hip
-# -x hip causes linker error
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -x hip -IC:/hip/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -IC:/hip/include/hip -D__HIP_PLATFORM_HCC__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
-
-
-# set(GTEST_DIR "C:/rocm/Utils/GTestMSVC")
-# set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
-# set(GTEST_LIBRARY "${GTEST_DIR}/lib/Release/gtest.lib")
-# set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/lib/Release/gtest_main.lib")
-# set(GTEST_LIBRARIES "${GTEST_DIR}/lib/Release/gtest.lib;${GTEST_DIR}/lib/Release/gtest_main.lib")

--- a/toolchain-windows.cmake
+++ b/toolchain-windows.cmake
@@ -28,7 +28,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_CRT_SECURE_NO_WARNINGS")
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fms-extensions -fms-compatibility -Wno-ignored-attributes")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__ -DHIP_CLANG_HCC_COMPAT_MODE=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_AMD__ -D__HIP_ROCclr__")
 
 if (DEFINED ENV{VCPKG_PATH})
   file(TO_CMAKE_PATH "$ENV{VCPKG_PATH}" VCPKG_PATH)


### PR DESCRIPTION
- Use _WIN32 instead of WIN32
- Remove checks for C++11 during compile time
- Fix compilation for `transform_iterator` with `__device__`-only operators
- Remove references to hcc
- Fix some warnings
- Fix missing gtest dependency