### PR TITLE
Treat Doxygen warnings as errors

### DIFF
--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -733,7 +733,13 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
+
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
+# a warning is encountered.
+# The default value is: NO.
+
+WARN_AS_ERROR          = YES
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters

--- a/docs/.doxygen/Doxyfile
+++ b/docs/.doxygen/Doxyfile
@@ -733,7 +733,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_UNDOCUMENTED   = YES
 
 # If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
 # a warning is encountered.

--- a/thrust/complex.h
+++ b/thrust/complex.h
@@ -29,6 +29,8 @@
 #include <sstream>
 #include <thrust/detail/type_traits.h>
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
 #if THRUST_CPP_DIALECT >= 2011
 #  define THRUST_STD_COMPLEX_REAL(z) \
     reinterpret_cast< \
@@ -44,6 +46,8 @@
 #  define THRUST_STD_COMPLEX_IMAG(z) (z).imag()
 #  define THRUST_STD_COMPLEX_DEVICE
 #endif
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/device_allocator.h
+++ b/thrust/device_allocator.h
@@ -67,12 +67,23 @@ public:
     {
     }
 
+    /*! Allocates space using the upstream resource.
+     *
+     *  \param bytes - the size of the requested allocation, in bytes
+     *  \param alignment - alignment size, in bytes
+     *  \return a pointer to the newly allocated storage.
+     */
     THRUST_NODISCARD __host__
     virtual pointer do_allocate(std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
     {
         return pointer(m_upstream->do_allocate(bytes, alignment).get());
     }
 
+    /*! Deallocates space that was previously allocated using this allocator.
+     * \param p - the pointer that was previously returned by \p do_allocate
+    *  \param bytes - size of the allocation, in bytes
+    *  \param alignment - alignment size, in bytes
+     */
     __host__
     virtual void do_deallocate(pointer p, std::size_t bytes, std::size_t alignment) override
     {
@@ -127,6 +138,7 @@ public:
     __host__ __device__
     device_allocator(const device_allocator<U>& other) : base(other) {}
 
+    /*! Use the default equality comparator. */
     device_allocator & operator=(const device_allocator &) = default;
 
     /*! Destructor has no effect. */

--- a/thrust/device_malloc.h
+++ b/thrust/device_malloc.h
@@ -61,8 +61,7 @@ THRUST_NAMESPACE_BEGIN
 template<typename T>
 inline thrust::device_ptr<T> device_malloc(const std::size_t n);
 
-/*! This version of \p device_malloc allocates sequential device storage
- *  for bytes.
+/*! This version of \p device_malloc allocates untyped sequential device storage.
  *
  *  \param n The number of bytes to allocate sequentially
  *           in device memory.

--- a/thrust/device_malloc.h
+++ b/thrust/device_malloc.h
@@ -30,36 +30,6 @@ THRUST_NAMESPACE_BEGIN
  *  \{
  */
 
-/*! This version of \p device_malloc allocates sequential device storage
- *  for bytes.
- *
- *  \param n The number of bytes to allocate sequentially
- *           in device memory.
- *  \return A \p device_ptr to the newly allocated memory.
- *
- *  The following code snippet demonstrates how to use \p device_malloc to
- *  allocate a range of device memory.
- *
- *  \code
- *  #include <thrust/device_malloc.h>
- *  #include <thrust/device_free.h>
- *  ...
- *  // allocate some memory with device_malloc
- *  const int N = 100;
- *  thrust::device_ptr<void> void_ptr = thrust::device_malloc(N);
- *
- *  // manipulate memory
- *  ...
- *
- *  // deallocate with device_free
- *  thrust::device_free(void_ptr);
- *  \endcode
- *
- *  \see device_ptr
- *  \see device_free
- */
-inline thrust::device_ptr<void> device_malloc(const std::size_t n);
-
 /*! This version of \p device_malloc allocates sequential device storage for
  *  new objects of the given type.
  *
@@ -89,7 +59,38 @@ inline thrust::device_ptr<void> device_malloc(const std::size_t n);
  *  \see device_free
  */
 template<typename T>
-  inline thrust::device_ptr<T> device_malloc(const std::size_t n);
+inline thrust::device_ptr<T> device_malloc(const std::size_t n);
+
+/*! This version of \p device_malloc allocates sequential device storage
+ *  for bytes.
+ *
+ *  \param n The number of bytes to allocate sequentially
+ *           in device memory.
+ *  \return A \p device_ptr to the newly allocated memory.
+ *
+ *  The following code snippet demonstrates how to use \p device_malloc to
+ *  allocate a range of device memory.
+ *
+ *  \code
+ *  #include <thrust/device_malloc.h>
+ *  #include <thrust/device_free.h>
+ *  ...
+ *  // allocate some memory with device_malloc
+ *  const int N = 100;
+ *  thrust::device_ptr<void> void_ptr = thrust::device_malloc(N);
+ *
+ *  // manipulate memory
+ *  ...
+ *
+ *  // deallocate with device_free
+ *  thrust::device_free(void_ptr);
+ *  \endcode
+ *
+ *  \see device_ptr
+ *  \see device_free
+ */
+template<>
+inline thrust::device_ptr<void> device_malloc(const std::size_t n);
 
 /*! \} // memory_management
  */

--- a/thrust/device_malloc_allocator.h
+++ b/thrust/device_malloc_allocator.h
@@ -30,8 +30,9 @@
 
 THRUST_NAMESPACE_BEGIN
 
-// forward declarations to WAR circular #includes
+/// forward declaration to WAR circular \#includes
 template<typename> class device_ptr;
+/// forward declaration
 template<typename T> device_ptr<T> device_malloc(const std::size_t n);
 
 /*! \addtogroup allocators Allocators 

--- a/thrust/device_ptr.h
+++ b/thrust/device_ptr.h
@@ -37,7 +37,7 @@ template <typename T> class device_reference;
  *  resides in memory associated with the \ref device system.
  *
  *  \c device_ptr has pointer semantics: it may be dereferenced safely from
- *  anywhere, including the \ref host, and may be manipulated with pointer
+ *  anywhere, including the host, and may be manipulated with pointer
  *  arithmetic.
  *
  *  \c device_ptr can be created with \ref device_new, \ref device_malloc,
@@ -88,7 +88,7 @@ class device_ptr
 
     /*! \brief Construct a null \c device_ptr.
      *
-     *  \param ptr A null pointer.
+     *  \param - A null pointer.
      *
      *  \post <tt>get() == nullptr</tt>.
      */
@@ -147,7 +147,7 @@ class device_ptr
 
     /*! \brief Set this \c device_ptr to null.
      *
-     *  \param ptr A null pointer.
+     *  \param - A null pointer.
      *
      *  \post <tt>get() == nullptr</tt>.
      *

--- a/thrust/fill.h
+++ b/thrust/fill.h
@@ -28,6 +28,7 @@ THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup transformations
  *  \addtogroup filling
+ *  \{
  *  \ingroup transformations
  *  \{
  */

--- a/thrust/functional.h
+++ b/thrust/functional.h
@@ -138,6 +138,8 @@ struct binary_function
  *  \{
  */
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
 #define THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(func, impl)                   \
   template <>                                                                  \
   struct func<void>                                                            \
@@ -171,6 +173,8 @@ struct binary_function
 #define THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(func, op)                 \
   THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION(                                   \
     func, THRUST_FWD(t1) op THRUST_FWD(t2))
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
 /*! \p plus is a function object. Specifically, it is an Adaptable Binary Function.
@@ -234,6 +238,8 @@ struct plus
   }
 }; // end plus
 
+/*! \brief Specialization of \p plus for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(plus, +);
 
 /*! \p minus is a function object. Specifically, it is an Adaptable Binary Function.
@@ -297,6 +303,8 @@ struct minus
   }
 }; // end minus
 
+/*! \brief Specialization of \p minus for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(minus, -);
 
 /*! \p multiplies is a function object. Specifically, it is an Adaptable Binary Function.
@@ -360,6 +368,8 @@ struct multiplies
   }
 }; // end multiplies
 
+/*! \brief Specialization of \p multiplies for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(multiplies, *);
 
 /*! \p divides is a function object. Specifically, it is an Adaptable Binary Function.
@@ -423,6 +433,8 @@ struct divides
   }
 }; // end divides
 
+/*! \brief Specialization of \p divides for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(divides, /);
 
 /*! \p modulus is a function object. Specifically, it is an Adaptable Binary Function.
@@ -486,6 +498,8 @@ struct modulus
   }
 }; // end modulus
 
+/*! \brief Specialization of \p modulus for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(modulus, %);
 
 /*! \p negate is a function object. Specifically, it is an Adaptable Unary Function.
@@ -541,6 +555,8 @@ struct negate
   }
 }; // end negate
 
+/*! \brief Specialization of \p negate for type void.
+ */
 THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(negate, -THRUST_FWD(x));
 
 /*! \p square is a function object. Specifically, it is an Adaptable Unary Function.
@@ -595,6 +611,8 @@ struct square
   }
 }; // end square
 
+/*! \brief Specialization of \p square for type void.
+ */
 THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(square, x*x);
 
 /*! \}
@@ -644,6 +662,8 @@ struct equal_to
   }
 }; // end equal_to
 
+/*! \brief Specialization of \p equal_to for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(equal_to, ==);
 
 /*! \p not_equal_to is a function object. Specifically, it is an Adaptable Binary
@@ -685,6 +705,8 @@ struct not_equal_to
   }
 }; // end not_equal_to
 
+/*! \brief Specialization of \p not_equal_to for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(not_equal_to, !=);
 
 /*! \p greater is a function object. Specifically, it is an Adaptable Binary
@@ -726,6 +748,8 @@ struct greater
   }
 }; // end greater
 
+/*! \brief Specialization of \p greater for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(greater, >);
 
 /*! \p less is a function object. Specifically, it is an Adaptable Binary
@@ -767,6 +791,8 @@ struct less
   }
 }; // end less
 
+/*! \brief Specialization of \p less for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(less, <);
 
 /*! \p greater_equal is a function object. Specifically, it is an Adaptable Binary
@@ -808,6 +834,8 @@ struct greater_equal
   }
 }; // end greater_equal
 
+/*! \brief Specialization of \p greater_equal for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(greater_equal, >=);
 
 /*! \p less_equal is a function object. Specifically, it is an Adaptable Binary
@@ -849,6 +877,8 @@ struct less_equal
   }
 }; // end less_equal
 
+/*! \brief Specialization of \p less_equal for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(less_equal, <=);
 
 /*! \}
@@ -899,6 +929,8 @@ struct logical_and
   }
 }; // end logical_and
 
+/*! \brief Specialization of \p logical_and for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(logical_and, &&);
 
 /*! \p logical_or is a function object. Specifically, it is an Adaptable Binary Predicate,
@@ -940,6 +972,8 @@ struct logical_or
   }
 }; // end logical_or
 
+/*! \brief Specialization of \p logical_or for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(logical_or, ||);
 
 /*! \p logical_not is a function object. Specifically, it is an Adaptable Predicate,
@@ -995,6 +1029,8 @@ struct logical_not
   }
 }; // end logical_not
 
+/*! \brief Specialization of \p logical_not for type void.
+ */
 THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(logical_not, !THRUST_FWD(x));
 
 /*! \}
@@ -1065,6 +1101,8 @@ struct bit_and
   }
 }; // end bit_and
 
+/*! \brief Specialization of \p bit_and for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(bit_and, &);
 
 /*! \p bit_or is a function object. Specifically, it is an Adaptable Binary Function.
@@ -1127,6 +1165,8 @@ struct bit_or
   }
 }; // end bit_or
 
+/*! \brief Specialization of \p bit_or for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(bit_or, |);
 
 /*! \p bit_xor is a function object. Specifically, it is an Adaptable Binary Function.
@@ -1189,6 +1229,8 @@ struct bit_xor
   }
 }; // end bit_xor
 
+/*! \brief Specialization of \p bit_xor for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION_OP(bit_xor, ^);
 
 /*! \}
@@ -1242,6 +1284,8 @@ struct identity
   }
 }; // end identity
 
+/*! \brief Specialization of \p identity for type void.
+ */
 THRUST_UNARY_FUNCTOR_VOID_SPECIALIZATION(identity, THRUST_FWD(x));
 
 /*! \p maximum is a function object that takes two arguments and returns the greater
@@ -1296,6 +1340,8 @@ struct maximum
   }
 }; // end maximum
 
+/*! \brief Specialization of \p maximum for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION(maximum,
                                           t1 < t2 ? THRUST_FWD(t2)
                                                   : THRUST_FWD(t1));
@@ -1352,6 +1398,8 @@ struct minimum
   }
 }; // end minimum
 
+/*! \brief Specialization of \p minimum for type void.
+ */
 THRUST_BINARY_FUNCTOR_VOID_SPECIALIZATION(minimum,
                                           t1 < t2 ? THRUST_FWD(t1)
                                                   : THRUST_FWD(t2));
@@ -1401,10 +1449,15 @@ struct project1st
   }
 }; // end project1st
 
+/*! \brief Specialization of \p project1st for two void arguments.
+ */
 template <>
 struct project1st<void, void>
 {
+  /// Indicate that this functor is transparent: it accepts any argument that can be
+  /// converted to the required type, and uses perfect forwarding.
   using is_transparent = void;
+  /// \brief Invocation operator - returns its first argument.
   __thrust_exec_check_disable__
   template <typename T1, typename T2>
   __host__ __device__
@@ -1461,10 +1514,15 @@ struct project2nd
   }
 }; // end project2nd
 
+/*! \brief Specialization of \p project2nd for two void arguments.
+ */
 template <>
 struct project2nd<void, void>
 {
+  /// Indicate that this functor is transparent: it accepts any argument that can be
+  /// converted to the required type, and uses perfect forwarding.
   using is_transparent = void;
+  /// \brief Invocation operator - returns its second argument.
   __thrust_exec_check_disable__
   template <typename T1, typename T2>
   __host__ __device__

--- a/thrust/memory.h
+++ b/thrust/memory.h
@@ -304,6 +304,7 @@ void free(const thrust::detail::execution_policy_base<DerivedPolicy> &system, Po
  *
  *  \param system The Thrust system with which the storage is associated.
  *  \param p A pointer previously returned by \p thrust::get_temporary_buffer. If \p ptr is null, \p return_temporary_buffer does nothing.
+ *  \param n
  *
  *  \tparam DerivedPolicy The name of the derived execution policy.
  *
@@ -363,7 +364,7 @@ typename thrust::detail::pointer_traits<Pointer>::raw_pointer
  *  If the argument is not a reference wrapper, the result is a reference to the argument.
  *
  *  \param ref The reference of interest.
- *  \return <tt>*thrust::raw_pointer_cast(&ref)</tt>.
+ *  \return <tt>*raw_pointer_cast(&ref)</tt>.
  *  \note There are two versions of \p raw_reference_cast. One for <tt>const</tt> references,
  *        and one for non-<tt>const</tt>.
  *  \see raw_pointer_cast
@@ -380,7 +381,7 @@ typename detail::raw_reference<T>::type
  *  If the argument is not a reference wrapper, the result is a reference to the argument.
  *
  *  \param ref The reference of interest.
- *  \return <tt>*thrust::raw_pointer_cast(&ref)</tt>.
+ *  \return <tt>*raw_reference_cast(&ref)</tt>.
  *  \note There are two versions of \p raw_reference_cast. One for <tt>const</tt> references,
  *        and one for non-<tt>const</tt>.
  *  \see raw_pointer_cast

--- a/thrust/mr/allocator.h
+++ b/thrust/mr/allocator.h
@@ -15,7 +15,7 @@
  */
 
 /*! \file 
- *  \brief Allocator types usable with \ref Memory Resources.
+ *  \brief Allocator types usable with \ref memory_resources.
  */
 
 #pragma once

--- a/thrust/mr/allocator.h
+++ b/thrust/mr/allocator.h
@@ -171,14 +171,27 @@ bool operator!=(const allocator<T, MR> & lhs, const allocator<T, MR> & rhs) noex
 
 #if THRUST_CPP_DIALECT >= 2011
 
+/*! An allocator whose memory resource we can dynamically configure at runtime.
+ *
+ * \tparam T - the type that will be allocated by this allocator
+ * \tparam Pointer - the pointer type that will be used to create the memory resource
+ */
 template<typename T, typename Pointer>
 using polymorphic_allocator = allocator<T, polymorphic_adaptor_resource<Pointer> >;
 
 #else // C++11
 
+/*! An allocator whose behaviour depends on a memory resource that we can dynamically configure at runtime.
+ *
+ * \tparam T - the type that will be allocated by this allocator
+ * \tparam Pointer - the pointer type that will be used to create the memory resource
+ */
 template<typename T, typename Pointer>
 class polymorphic_allocator : public allocator<T, polymorphic_adaptor_resource<Pointer> >
 {
+    /// Use a regular allocator, created with a polymorphic_adaptor_resource memory resource,
+    /// an instance of which we can pass into the constructor.
+    /// The polymorphic_adaptor_resource can implement custom allocation behaviour.
     typedef allocator<T, polymorphic_adaptor_resource<Pointer> > base;
 
 public:

--- a/thrust/mr/fancy_pointer_resource.h
+++ b/thrust/mr/fancy_pointer_resource.h
@@ -26,24 +26,50 @@ THRUST_NAMESPACE_BEGIN
 namespace mr
 {
 
+/*! A \p memory_resource derived class that wraps a pointer type.
+ *
+ * Wrapping the pointer type allows this class to use either the global (static) memory
+ * resource (see \p mr::get_global_resource ), or a provided "upstream" memory resource
+ * instance. When allocations are performed, the returned pointer is cast to the \p Pointer
+ * template parameter type, for convenience.
+ *
+ * \tparam Upstream - a \p memory_resource derrived type. Will be wrapped by this class.
+ * \tparam Pointer - when allocations are performed, the return value will be cast to this type.
+ */
 template<typename Upstream, typename Pointer>
 class fancy_pointer_resource final : public memory_resource<Pointer>, private validator<Upstream>
 {
 public:
+    /*! Constructs a pointer to the global (static) memory resource.
+     * See \p mr::get_global_resource.
+     */
     fancy_pointer_resource() : m_upstream(get_global_resource<Upstream>())
     {
     }
 
+    /*! Constructs a pointer to the provided memory resource.
+     * \param upstream - pointer to the memory_resource to wrap.
+     */
     fancy_pointer_resource(Upstream * upstream) : m_upstream(upstream)
     {
     }
 
+    /*! Performs a memory allocation. Returns a pointer of type \p Pointer.
+     * \param bytes - the requested size of the allocation, in bytes
+     * \param alignment - specifies the alignment for the allocation.
+     *  Defaults to THRUST_MR_DEFAULT_ALIGNMENT.
+     */
     THRUST_NODISCARD
     virtual Pointer do_allocate(std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
     {
         return static_cast<Pointer>(m_upstream->do_allocate(bytes, alignment));
     }
 
+    /*! Deallocates memory that was previously allocated with this allocator.
+     * \param p - pointer to the memory that was previously allocated by \p do_allocate
+     * \param bytes - the size of the allocation that was requested, in bytes
+     * \param alignment - specifies the alignment that was used for the allocation
+     */
     virtual void do_deallocate(Pointer p, std::size_t bytes, std::size_t alignment) override
     {
         return m_upstream->do_deallocate(

--- a/thrust/mr/memory_resource.h
+++ b/thrust/mr/memory_resource.h
@@ -126,6 +126,7 @@ public:
     }
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip void specialized implementation
 template<>
 class memory_resource<void *>
 #ifdef THRUST_STD_MR_NS
@@ -177,6 +178,7 @@ public:
     }
 #endif
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /*! Compares the memory resources for equality, first by identity, then by \p is_equal.
  */

--- a/thrust/mr/polymorphic_adaptor.h
+++ b/thrust/mr/polymorphic_adaptor.h
@@ -24,24 +24,53 @@ THRUST_NAMESPACE_BEGIN
 namespace mr
 {
 
+/*! This memory_resource-derived type provides the ability to implement custom allocation behaviour.
+ *
+ * Since this class inherits from \p memory_resource, an instance of this class can be passed
+ * to an allocator constructor (as a memory resource).
+ * This class also wraps a \p memory_resource. When interface member functions are called
+ * (eg. do_allocate), the underlying (wrapped) \p memory_resource's corresponding member functions
+ * are invoked.
+ * Together, these two properties enable \p polymorphic_adaptor_resource to be used in the
+ * implementation of a polymorphic allocator: an allocator whose behaviour is specified at runtime.
+ *
+ * \tparam Pointer - the pointer type that will be used to create the memory resource.
+ * Defaults to void*.
+ */
 template<typename Pointer = void *>
 class polymorphic_adaptor_resource final : public memory_resource<Pointer>
 {
 public:
+    /*! Constructs a new \p polymorphic_adaptor_resource
+     * \param t - A pointer to a memory_resource that this instance will wrap.
+     */
     polymorphic_adaptor_resource(memory_resource<Pointer> * t) : upstream_resource(t)
     {
     }
 
+    /*! Performs a memory allocation.
+     * \param bytes - the requested size of the allocation, in bytes
+     * \param alignment - specifies the alignment for the allocation.
+     *  Defaults to THRUST_MR_DEFAULT_ALIGNMENT.
+     */
     virtual Pointer do_allocate(std::size_t bytes, std::size_t alignment = THRUST_MR_DEFAULT_ALIGNMENT) override
     {
         return upstream_resource->allocate(bytes, alignment);
     }
 
+    /*! Deallocates memory that was previously allocated with this allocator.
+     * \param p - pointer to the memory that was previously allocated by \p do_allocate
+     * \param bytes - the size of the allocation that was requested, in bytes
+     * \param alignment - specifies the alignment that was used for the allocation
+     */
     virtual void do_deallocate(Pointer p, std::size_t bytes, std::size_t alignment) override
     {
         return upstream_resource->deallocate(p, bytes, alignment);
     }
 
+    /*! Compares this \p polymorphic_adaptor_resource with another \p memory_resource
+     * to see if they are equal.
+     */
     __host__ __device__
     virtual bool do_is_equal(const memory_resource<Pointer> & other) const noexcept override
     {

--- a/thrust/partition.h
+++ b/thrust/partition.h
@@ -1197,9 +1197,6 @@ template<typename InputIterator1,
                           Predicate pred);
 
 
-/*! \} // end stream_compaction
- */
-
 /*! \} // end reordering
  */
 

--- a/thrust/replace.h
+++ b/thrust/replace.h
@@ -28,6 +28,7 @@ THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup transformations
  *  \addtogroup replacing
+ *  \{
  *  \ingroup transformations
  *  \{
  */

--- a/thrust/reverse.h
+++ b/thrust/reverse.h
@@ -27,6 +27,7 @@
 THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup reordering
+ *  \{
  *  \ingroup algorithms
  */
 

--- a/thrust/scan.h
+++ b/thrust/scan.h
@@ -15,7 +15,7 @@
  */
 
 
-/*! \file scan.h
+/*! \file thrust/scan.h
  *  \brief Functions for computing prefix sums
  */
 

--- a/thrust/system/system_error.h
+++ b/thrust/system/system_error.h
@@ -164,10 +164,10 @@ class system_error
      */
 }; // end system_error
 
-} // end system
-
 /*! \} // end system_diagnostics
  */
+
+} // end system
 
 // import names into thrust::
 using system::system_error;

--- a/thrust/uninitialized_fill.h
+++ b/thrust/uninitialized_fill.h
@@ -27,6 +27,7 @@
 THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup filling
+ *  \{
  *  \ingroup transformations
  *  \{
  */

--- a/thrust/unique.h
+++ b/thrust/unique.h
@@ -1014,7 +1014,6 @@ __host__ __device__
  *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input range.
  *  \param last  The end of the input range.
- *  \param binary_pred  The binary predicate used to determine equality.
  *  \return The number of runs of equal elements in <tt>[first, new_last)</tt>
  *
  *  \tparam DerivedPolicy The name of the derived execution policy.
@@ -1054,7 +1053,6 @@ __host__ __device__
  *
  *  This version of \p unique_count uses the function object \p binary_pred to test for equality.
  *
- *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input range.
  *  \param last  The end of the input range.
  *  \param binary_pred  The binary predicate used to determine equality.
@@ -1096,10 +1094,8 @@ __host__ __device__
  *
  *  This version of \p unique_count uses \c operator== to test for equality.
  *
- *  \param exec The execution policy to use for parallelization.
  *  \param first The beginning of the input range.
  *  \param last  The end of the input range.
- *  \param binary_pred  The binary predicate used to determine equality.
  *  \return The number of runs of equal elements in <tt>[first, new_last)</tt>
  *
  *  \tparam DerivedPolicy The name of the derived execution policy.

--- a/thrust/universal_allocator.h
+++ b/thrust/universal_allocator.h
@@ -24,10 +24,14 @@
 
 #include <thrust/detail/config.h>
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+
 // #include the device system's vector header
 #define __THRUST_DEVICE_SYSTEM_MEMORY_HEADER <__THRUST_DEVICE_SYSTEM_ROOT/memory.h>
 #include __THRUST_DEVICE_SYSTEM_MEMORY_HEADER
 #undef __THRUST_DEVICE_SYSTEM_MEMORY_HEADER
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/universal_vector.h
+++ b/thrust/universal_vector.h
@@ -24,10 +24,14 @@
 #include <thrust/detail/config.h>
 #include <thrust/universal_allocator.h>
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // skip overloaded implementation
+
 // #include the device system's vector header
 #define __THRUST_DEVICE_SYSTEM_VECTOR_HEADER <__THRUST_DEVICE_SYSTEM_ROOT/vector.h>
 #include __THRUST_DEVICE_SYSTEM_VECTOR_HEADER
 #undef __THRUST_DEVICE_SYSTEM_VECTOR_HEADER
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 THRUST_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Treat Doxygen warnings as errors
* Turned on WARN_AS_ERROR in the Doxyfile
* Added missing documentation (since it now generates errors)
* Moved group start/end braces to fix balancing errors