### PR TITLE
Change device_malloc specialization to instantiation

### DIFF
--- a/thrust/device_malloc.h
+++ b/thrust/device_malloc.h
@@ -88,7 +88,6 @@ inline thrust::device_ptr<T> device_malloc(const std::size_t n);
  *  \see device_ptr
  *  \see device_free
  */
-template<>
 inline thrust::device_ptr<void> device_malloc(const std::size_t n);
 
 /*! \} // memory_management


### PR DESCRIPTION
I believe that #321 introduced a typo when moving around the template declaration and (previously) template instantiation - by adding template<> to the instantiation, it instead became a template specialization declaration.  As a result, a customer has reported that including device_malloc_allocator.h in multiple files now results in duplicate symbol errors during compilation.  

This change merely reverts the code to what it was prior to the PR.  cppcheck seems fine with it, hence my theory it was a typo - @umfranzw do you recall if this was intentional or not?

What does seem a little odd is that we get duplicate symbol errors despite the specialization having the inline keyword, as well as the #pragma once guard...at first thought I would think they would prevent this from happening.