### PR TITLE
Fixed segfault in HIP binary search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Full documentation for rocThrust is available at [https://rocthrust.readthedocs.
 - The cmake build system now additionally accepts `GPU_TARGETS` in addition to `AMDGPU_TARGETS` for
   setting the targeted gpu architectures. `GPU_TARGETS=all` will compile for all supported architectures.
   `AMDGPU_TARGETS` is only provided for backwards compatibility, `GPU_TARGETS` should be preferred.
+### Fixed
+- Fixed a segmentation fault when binary search / upper bound / lower bound / equal range was invoked with `hip_rocprim::execute_on_stream_base` policy.
 ### Known issues
 - For NVIDIA backend, `NV_IF_TARGET` and `THRUST_RDC_ENABLED` intend to substitute the `THRUST_HAS_CUDART` macro, which is now no longer used in Thrust (provided for legacy support only). However, there is no `THRUST_RDC_ENABLED` macro available for the HIP backend, so some branches in Thrust's code may be unreachable in the HIP backend.
 

--- a/thrust/system/hip/detail/binary_search.h
+++ b/thrust/system/hip/detail/binary_search.h
@@ -464,12 +464,38 @@ HaystackIt lower_bound(execution_policy<Derived>& policy,
             values_type  values(policy, 1);
             results_type result(policy, 1);
 
-            values[0] = value;
+            {
+                typedef typename thrust::iterator_system<const T*>::type value_in_system_t;
+                value_in_system_t                                        value_in_system;
+                using thrust::system::detail::generic::select_system;
+                thrust::copy_n(
+                    select_system(
+                        thrust::detail::derived_cast(thrust::detail::strip_const(value_in_system)),
+                        thrust::detail::derived_cast(thrust::detail::strip_const(policy))),
+                    &value,
+                    1,
+                    values.begin());
+            }
 
             __binary_search::lower_bound(
                 policy, first, last, values.begin(), values.end(), result.begin(), compare_op);
 
-            return first + result[0];
+            difference_type h_result;
+            {
+                typedef
+                    typename thrust::iterator_system<difference_type*>::type result_out_system_t;
+                result_out_system_t                                          result_out_system;
+                using thrust::system::detail::generic::select_system;
+                thrust::copy_n(
+                    select_system(thrust::detail::derived_cast(thrust::detail::strip_const(policy)),
+                                  thrust::detail::derived_cast(
+                                      thrust::detail::strip_const(result_out_system))),
+                    result.begin(),
+                    1,
+                    &h_result);
+            }
+
+            return first + h_result;
         }
 
         __device__
@@ -524,13 +550,39 @@ HaystackIt upper_bound(execution_policy<Derived>& policy,
           values_type values(policy, 1);
           results_type result(policy, 1);
 
-          values[0] = value;
+          {
+                typedef typename thrust::iterator_system<const T*>::type value_in_system_t;
+                value_in_system_t                                        value_in_system;
+                using thrust::system::detail::generic::select_system;
+                thrust::copy_n(
+                    select_system(
+                        thrust::detail::derived_cast(thrust::detail::strip_const(value_in_system)),
+                        thrust::detail::derived_cast(thrust::detail::strip_const(policy))),
+                    &value,
+                    1,
+                    values.begin());
+          }
 
           __binary_search::upper_bound(
               policy, first, last, values.begin(), values.end(), result.begin(), compare_op
           );
 
-          return first + result[0];
+          difference_type h_result;
+          {
+                typedef
+                    typename thrust::iterator_system<difference_type*>::type result_out_system_t;
+                result_out_system_t                                          result_out_system;
+                using thrust::system::detail::generic::select_system;
+                thrust::copy_n(
+                    select_system(thrust::detail::derived_cast(thrust::detail::strip_const(policy)),
+                                  thrust::detail::derived_cast(
+                                      thrust::detail::strip_const(result_out_system))),
+                    result.begin(),
+                    1,
+                    &h_result);
+          }
+
+          return first + h_result;
         }
 
         __device__
@@ -583,13 +635,38 @@ bool binary_search(execution_policy<Derived>& policy,
           values_type values(policy, 1);
           results_type result(policy, 1);
 
-          values[0] = value;
+          {
+                typedef typename thrust::iterator_system<const T*>::type value_in_system_t;
+                value_in_system_t                                        value_in_system;
+                using thrust::system::detail::generic::select_system;
+                thrust::copy_n(
+                    select_system(
+                        thrust::detail::derived_cast(thrust::detail::strip_const(value_in_system)),
+                        thrust::detail::derived_cast(thrust::detail::strip_const(policy))),
+                    &value,
+                    1,
+                    values.begin());
+          }
 
           __binary_search::binary_search(
               policy, first, last, values.begin(), values.end(), result.begin(), compare_op
           );
 
-          return result[0] != 0;
+          int h_result;
+          {
+                typedef typename thrust::iterator_system<int*>::type result_out_system_t;
+                result_out_system_t                                  result_out_system;
+                using thrust::system::detail::generic::select_system;
+                thrust::copy_n(
+                    select_system(thrust::detail::derived_cast(thrust::detail::strip_const(policy)),
+                                  thrust::detail::derived_cast(
+                                      thrust::detail::strip_const(result_out_system))),
+                    result.begin(),
+                    1,
+                    &h_result);
+          }
+
+          return h_result != 0;
         }
 
         __device__


### PR DESCRIPTION
- Fixed a segfault by using a different way of host->device and device->host copies. The copy using the class "reference" cannot have access to the state of the underlying thrust system. This caused a segfault when the HIP stream selector system is used, because it tries to access the system (`nullptr`) for a stream.
- The incantation that is the new implementation is borrowed from the cuda system.
- Additionally a new test case has been added to cover this.