### PR TITLE
Standardize documentation for ReadtheDocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,13 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/docs/.sphinx" # Location of package manifests
+    directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    labels:
+      - "documentation"
+      - "dependencies"
+      - "ci:docs-only"
+    reviewers:
+      - "samjwu"

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 ### Build dirs ###
 build/
 
-### Docs dirs ###
-doc/html/
-doc/xml/
-doc/latex/
-doc/*.tag
-
 # Created by https://www.gitignore.io/api/c++,cmake
 
 ### C++ ###

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,7 @@ python:
 build:
    os: ubuntu-22.04
    tools:
-      python: "3.8"
+      python: "mambaforge-22.9"
+
+conda:
+   environment: docs/environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,13 +6,13 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip]
+formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/.sphinx/requirements.txt
+   - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-22.04
    tools:
       python: "3.8"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can build our documentation locally using the following commands:
 cd rocThrust; cd docs
 
 # Install Python dependencies
-python3 -m pip install -r .sphinx/requirements.txt
+python3 -m pip install -r sphinx/requirements.txt
 
 # Build the documentation
 python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,7 +1,5 @@
 /_build
 /_doxygen
-/_images
-/_static
-/_templates
-/.doxygen/docBin
-/.sphinx/_toc.yml
+/doxygen/html/
+/doxygen/xml/
+/sphinx/_toc.yml

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,0 @@
-rocm-docs-core>=0.24.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,13 +4,30 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import re
+
 from rocm_docs import ROCmDocs
+with open('../CMakeLists.txt', encoding='utf-8') as f:
+    match = re.search(r'rocm_setup_version\(VERSION\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    if not match:
+        raise ValueError("VERSION not found!")
+    version_number = match[1]
+left_nav_title = f"rocThrust {version_number} Documentation"
+
+# for PDF output on Read the Docs
+project = "rocThrust Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
+
+external_toc_path = "./sphinx/_toc.yml"
+
+docs_core = ROCmDocs(left_nav_title)
+docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
+docs_core.setup()
 
 external_projects_current_project = "rocthrust"
-
-docs_core = ROCmDocs("rocThrust Documentation")
-docs_core.run_doxygen(doxygen_root=".doxygen", doxygen_path=".doxygen/docBin/xml")
-docs_core.setup()
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docBin
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -828,7 +828,8 @@ INPUT                  = ../../thrust \
                          ../../thrust/iterator \
                          ../../thrust/mr \
                          ../../thrust/random \
-                         ../../thrust/system
+                         ../../thrust/system \
+                         ../../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -979,7 +980,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../README.md
+USE_MDFILE_AS_MAINPAGE = ../../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,10 @@
+name: RTD
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - doxygen=1.9.8
+  - pip:
+    - -r ./sphinx/requirements.txt

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../LICENSE

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -10,3 +10,6 @@ subtrees:
 - caption: API
   entries:
   - file: cpp_api
+- caption: About
+  entries:
+  - file: license

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,1 @@
+rocm-docs-core==0.30.3

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -84,9 +84,7 @@ pygments==2.15.0
     #   pydata-sphinx-theme
     #   sphinx
 pyjwt[crypto]==2.6.0
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pynacl==1.5.0
     # via pygithub
 pytz==2023.3.post1


### PR DESCRIPTION
Apply the following changes to project documentation for ReadtheDocs:

add version number to documentation left navigation bar and page title
add an "About" section with a license page
enable htmlzip, pdf, epub formats when publishing on Read the Docs
set pdf title, author, copyright, and version
rename .sphinx/.doxygen to sphinx/doxygen
update rocm-docs-core dependency
update dependabot config

relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330


# Note

Runs a custom virtual environment via conda (mambaforge) for ReadtheDocs for doxygen 1.9.8 due to doxygen 1.9.1 (default for Ubuntu 22.04) segfaulting on rocThrust documentation