### PR TITLE
thrust::optional preserves trivially copyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocThrust available at
 [https://rocm.docs.amd.com/projects/rocThrust/en/latest/](https://rocm.docs.amd.com/projects/rocThrust/en/latest/).
 
-## (Unreleased) rocThrust 3.x.x for ROCm 6.1
+## (Unreleased) rocThrust 3.0.1 for ROCm 6.1
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for rocThrust available at
 [https://rocm.docs.amd.com/projects/rocThrust/en/latest/](https://rocm.docs.amd.com/projects/rocThrust/en/latest/).
 
+## (Unreleased) rocThrust 3.x.x for ROCm 6.1
+
+### Fixes
+
+* Ported a fix from thrust 2.2 that ensures `thrust::optional` is trivially copyable.
+
 ## rocThrust 3.0.0 for ROCm 6.0
 ### Additions
 - Updated to match upstream Thrust 2.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 
 # Setup VERSION
-rocm_setup_version(VERSION "3.0.0")
+rocm_setup_version(VERSION "3.0.1")
 
 # Print configuration summary
 include(cmake/Summary.cmake)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2019-2023 Advanced Micro Devices, Inc.
+# Copyright 2019-2024 Advanced Micro Devices, Inc.
 # ########################################################################
 
 set(INSTALL_TEST_FILE "${CMAKE_CURRENT_BINARY_DIR}/install_CTestTestfile.cmake")
@@ -167,6 +167,7 @@ add_rocthrust_test("mr_disjoint_pool")
 add_rocthrust_test("mr_new")
 add_rocthrust_test("mr_pool")
 add_rocthrust_test("mr_pool_options")
+add_rocthrust_test("optional")
 add_rocthrust_test("pair")
 add_rocthrust_test("pair_reduce")
 add_rocthrust_test("pair_scan")

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -1,0 +1,30 @@
+/*
+ *  Copyright© 2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "test_header.hpp"
+
+#include <thrust/optional.h>
+
+#include <cstdint>
+#include <type_traits>
+
+TEST(OptionalTests, IsTriviallyCopyable)
+{
+    static_assert(std::is_trivially_copyable<uint64_t>::value == true,
+                  "type is not trivially copyable even though it should be!");
+    static_assert(std::is_trivially_copyable<thrust::optional<uint64_t>>::value == true,
+                  "type is not trivially copyable even though it should be!");
+}

--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -117,7 +117,7 @@ THRUST_NAMESPACE_END
 
 #if defined(__GLIBCXX__) && __has_feature(is_trivially_assignable)
 #define THRUST_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
-  __is_trivially_assignable(T, T const&)
+  __is_trivially_assignable(T&, T const&)
 #else
 #define THRUST_OPTIONAL_IS_TRIVIALLY_COPY_ASSIGNABLE(T) \
   std::is_trivially_copy_assignable<T>::value
@@ -133,7 +133,7 @@ THRUST_NAMESPACE_END
 
 #if defined(__GLIBCXX__) && __has_feature(is_trivially_assignable)
 #define THRUST_OPTIONAL_IS_TRIVIALLY_MOVE_ASSIGNABLE(T) \
-  __is_trivially_assignable(T, T&&)
+  __is_trivially_assignable(T&, T&&)
 #else
 #define THRUST_OPTIONAL_IS_TRIVIALLY_MOVE_ASSIGNABLE(T) \
   std::is_trivially_move_assignable<T>::value
@@ -1580,7 +1580,7 @@ public:
 
     *this = nullopt;
     this->construct(std::forward<Args>(args)...);
-    return value();
+    return this->m_value;
   }
 
   /// \group emplace
@@ -1594,7 +1594,7 @@ public:
   emplace(std::initializer_list<U> il, Args &&... args) {
     *this = nullopt;
     this->construct(il, std::forward<Args>(args)...);
-    return value();
+    return this->m_value;
   }
 
   /// Swaps this optional with the other.
@@ -2873,3 +2873,4 @@ template <class T> struct hash<THRUST_NS_QUALIFIER::optional<T>> {
 } // namespace std
 
 #endif // THRUST_CPP_DIALECT >= 2011
+


### PR DESCRIPTION
This PR fixes thrust::optional not being trivially copyable. It was added in thrust 2.2. An additional test has also been added for sanity's sake.

CC @stanleytsang-amd 