### PR TITLE
Add overload of get_random_data() for windows

### DIFF
--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -151,9 +151,8 @@ std::vector<seed_type> get_seeds()
     return seeds;
 }
 
-#if defined(_WIN32) && defined(__clang__)
 template <class T>
-inline auto get_random_data(size_t size, T, T, int seed) ->
+inline auto get_random_data(size_t size, T, T, seed_type seed) ->
     typename std::enable_if<std::is_same<T, bool>::value, thrust::host_vector<T>>::type
 {
     std::random_device          rd;
@@ -166,7 +165,7 @@ inline auto get_random_data(size_t size, T, T, int seed) ->
 }
 
 template <class T>
-inline auto get_random_data(size_t size, T min, T max, int seed) ->
+inline auto get_random_data(size_t size, T min, T max, seed_type seed) ->
     typename std::enable_if<rocprim::is_integral<T>::value && !std::is_same<T, bool>::value,
                             thrust::host_vector<T>>::type
 {
@@ -180,7 +179,7 @@ inline auto get_random_data(size_t size, T min, T max, int seed) ->
 }
 
 template <class T>
-inline auto get_random_data(size_t size, T min, T max, int seed) ->
+inline auto get_random_data(size_t size, T min, T max, seed_type seed) ->
     typename std::enable_if<rocprim::is_floating_point<T>::value, thrust::host_vector<T>>::type
 {
     std::random_device                rd;
@@ -192,6 +191,7 @@ inline auto get_random_data(size_t size, T min, T max, int seed) ->
     return data;
 }
 
+#if defined(_WIN32) && defined(__clang__)
 template <>
 inline thrust::host_vector<unsigned char> get_random_data(size_t size, unsigned char min, unsigned char max, int seed_value)
 {
@@ -213,46 +213,6 @@ inline thrust::host_vector<signed char> get_random_data(size_t size, signed char
     std::uniform_int_distribution<int> distribution(static_cast<int>(min), static_cast<int>(max));
     thrust::host_vector<signed char> data(size);
     std::generate(data.begin(), data.end(), [&]() { return static_cast<signed char>(distribution(gen)); });
-    return data;
-}
-#else
-template <class T>
-inline auto get_random_data(size_t size, T, T, uint64_t seed) ->
-    typename std::enable_if<std::is_same<T, bool>::value, thrust::host_vector<T>>::type
-{
-    std::random_device          rd;
-    std::default_random_engine  gen(rd());
-    gen.seed(seed);
-    std::bernoulli_distribution distribution(0.5);
-    thrust::host_vector<T>      data(size);
-    std::generate(data.begin(), data.end(), [&]() { return distribution(gen); });
-    return data;
-}
-
-template <class T>
-inline auto get_random_data(size_t size, T min, T max, uint64_t seed) ->
-    typename std::enable_if<rocprim::is_integral<T>::value && !std::is_same<T, bool>::value,
-                            thrust::host_vector<T>>::type
-{
-    std::random_device               rd;
-    std::default_random_engine       gen(rd());
-    gen.seed(seed);
-    std::uniform_int_distribution<T> distribution(min, max);
-    thrust::host_vector<T>           data(size);
-    std::generate(data.begin(), data.end(), [&]() { return distribution(gen); });
-    return data;
-}
-
-template <class T>
-inline auto get_random_data(size_t size, T min, T max, uint64_t seed) ->
-    typename std::enable_if<rocprim::is_floating_point<T>::value, thrust::host_vector<T>>::type
-{
-    std::random_device                rd;
-    std::default_random_engine        gen(rd());
-    gen.seed(seed);
-    std::uniform_real_distribution<T> distribution(min, max);
-    thrust::host_vector<T>            data(size);
-    std::generate(data.begin(), data.end(), [&]() { return distribution(gen); });
     return data;
 }
 #endif

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -193,7 +193,7 @@ inline auto get_random_data(size_t size, T min, T max, seed_type seed) ->
 
 #if defined(_WIN32) && defined(__clang__)
 template <>
-inline thrust::host_vector<unsigned char> get_random_data(size_t size, unsigned char min, unsigned char max, int seed_value)
+inline thrust::host_vector<unsigned char> get_random_data(size_t size, unsigned char min, unsigned char max, seed_type seed_value)
 {
     std::random_device                 rd;
     std::default_random_engine         gen(rd());
@@ -205,7 +205,7 @@ inline thrust::host_vector<unsigned char> get_random_data(size_t size, unsigned 
 }
 
 template <>
-inline thrust::host_vector<signed char> get_random_data(size_t size, signed char min, signed char max, int seed_value)
+inline thrust::host_vector<signed char> get_random_data(size_t size, signed char min, signed char max, seed_type seed_value)
 {
     std::random_device                 rd;
     std::default_random_engine         gen(rd());


### PR DESCRIPTION
std::minstd_rand::result_type, which is [uint_fast32_t](https://cplusplus.com/reference/random/minstd_rand/) (used in https://github.com/ROCm/rocThrust/blob/develop/test/test_seed.in.hpp#L25) for get_seeds() in the unit tests is not the same in Linux and Windows - checking the size of the type in Visual Studio returns 4 bytes (probably just an int), in Linux it is 8 bytes.  This leads to build errors in Windows:

error: no function template matches function template specialization 'get_random_data'
[2024-03-23T15:53:40.267Z]   196 | inline thrust::host_vector<unsigned char> get_random_data(size_t size, unsigned char min, unsigned char max, int seed_value)
[2024-03-23T15:53:40.267Z]       |                                           ^
[2024-03-23T15:53:40.267Z] C:/jenkins/workspace/_rocmlibraries_rocthrust_staging/test\test_utils.hpp:155:13: note: candidate template ignored: could not match 'uint64_t' (aka 'unsigned long long') against 'int'
[2024-03-23T15:53:40.267Z]   155 | inline auto get_random_data(size_t size, T, T, uint64_t seed) -> 

I've added overloads specifically for Windows to account for the difference in implementation of uint_fast32_t.