### PR TITLE
Update type_traits.h.

### DIFF
--- a/thrust/detail/nv_target.h
+++ b/thrust/detail/nv_target.h
@@ -27,4 +27,8 @@
 #  include <thrust/system/hip/detail/nv/target.h>
 #elif THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 #  include <nv/target>
+#else
+// When using a different backend, e.g. OpenMP, we still need to define the target.
+// We can simply reuse the HIP targets for this.
+#  include <thrust/system/hip/detail/nv/target.h>
 #endif

--- a/thrust/detail/type_traits.h
+++ b/thrust/detail/type_traits.h
@@ -731,6 +731,8 @@ using invoke_result_t =
 #else // 2017+
   ::cuda::std::invoke_result_t<Invokable, Args...>;
 #endif
+#else
+  std::invoke_result_t<Invokable, Args...>;
 #endif
 
 template <class F, class... Us>


### PR DESCRIPTION
A regression was introduced in 2b80e29803d60f01701a67bc57ef06dacfe8af8b. In case of THRUST_DEVICE_SYSTEM_OMP build, the invoke_result_t is undefined due to missing #else branch. See e.g. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1064730