### PR TITLE
Adding bitwise reproducibility documentation

### DIFF
--- a/docs/bitwise-repro.rst
+++ b/docs/bitwise-repro.rst
@@ -8,7 +8,7 @@
 Bitwise reproducibility
 ******************************************
 
-With the exception of the below functions, all rocThrust API functions are bitwise reproducible - that is, given identical inputs, the function will return the exact same result in repeated invocations.
+With the exception of the following functions, all rocThrust API functions are bitwise reproducible - that is, given identical inputs, the function will return the exact same result in repeated invocations.
 
 * scan (inclusive & exclusive)
 * scan_by_key (inclusive & exclusive)

--- a/docs/bitwise-repro.rst
+++ b/docs/bitwise-repro.rst
@@ -1,0 +1,16 @@
+.. meta::
+  :description: rocThrust documentation and API reference
+  :keywords: rocThrust, ROCm, API, reference, data type, support
+  
+.. _bitwise-repro:
+
+******************************************
+Bitwise reproducibility
+******************************************
+
+With the exception of the below functions, all rocThrust API functions are bitwise reproducible - that is, given identical inputs, the function will return the exact same result in repeated invocations.
+
+* scan (inclusive & exclusive)
+* scan_by_key (inclusive & exclusive)
+* reduce_by_key
+* transform_scan

--- a/docs/bitwise-repro.rst
+++ b/docs/bitwise-repro.rst
@@ -8,7 +8,7 @@
 Bitwise reproducibility
 ******************************************
 
-With the exception of the following functions, all rocThrust API functions are bitwise reproducible - that is, given identical inputs, the function will return the exact same result in repeated invocations.
+With the exception of the following functions, all rocThrust API functions are bitwise reproducible.  That is, given identical inputs, the function will return the exact same result in repeated invocations.
 
 * scan (inclusive & exclusive)
 * scan_by_key (inclusive & exclusive)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ The documentation is structured as follows:
   .. grid-item-card:: API reference
 
     * :ref:`data-type-support`
-    * :ref: 'bitwise-repro'
+    * :ref:`bitwise-repro`
     * :ref:`api-reference`
     * :ref:`genindex`
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ The documentation is structured as follows:
   .. grid-item-card:: API reference
 
     * :ref:`data-type-support`
+    * :ref: 'bitwise-repro'
     * :ref:`api-reference`
     * :ref:`genindex`
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -12,6 +12,7 @@ subtrees:
 - caption: API reference
   entries:
   - file: data-type-support
+  - file: bitwise-repro
   - file: cpp_api
 
 - caption: About

--- a/thrust/reduce.h
+++ b/thrust/reduce.h
@@ -351,6 +351,8 @@ template<typename InputIterator,
  *  This version of \p reduce_by_key uses the function object \c equal_to
  *  to test for equality and \c plus to reduce values with equal keys.
  *
+ *  Results from this function may vary from run to run depending on the inputs provided.
+ *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
  *  \param exec The execution policy to use for parallelization.
@@ -421,6 +423,8 @@ __host__ __device__
  *  This version of \p reduce_by_key uses the function object \c equal_to
  *  to test for equality and \c plus to reduce values with equal keys.
  *
+ *  Results from this function may vary from run to run depending on the inputs provided.
+ *
  *  \param keys_first The beginning of the input key range.
  *  \param keys_last  The end of the input key range.
  *  \param values_first The beginning of the input value range.
@@ -481,6 +485,8 @@ template<typename InputIterator1,
  *
  *  This version of \p reduce_by_key uses the function object \c binary_pred
  *  to test for equality and \c plus to reduce values with equal keys.
+ *
+ *  Results from this function may vary from run to run depending on the inputs provided.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -557,6 +563,8 @@ __host__ __device__
  *  This version of \p reduce_by_key uses the function object \c binary_pred
  *  to test for equality and \c plus to reduce values with equal keys.
  *
+ *  Results from this function may vary from run to run depending on the inputs provided.
+ *
  *  \param keys_first The beginning of the input key range.
  *  \param keys_last  The end of the input key range.
  *  \param values_first The beginning of the input value range.
@@ -625,6 +633,8 @@ template<typename InputIterator1,
  *
  *  This version of \p reduce_by_key uses the function object \c binary_pred
  *  to test for equality and \c binary_op to reduce values with equal keys.
+ *
+ *  Results from this function may vary from run to run depending on the inputs provided.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -709,6 +719,8 @@ __host__ __device__
  *
  *  This version of \p reduce_by_key uses the function object \c binary_pred
  *  to test for equality and \c binary_op to reduce values with equal keys.
+ *
+ *  Results from this function may vary from run to run depending on the inputs provided.
  *
  *  \param keys_first The beginning of the input key range.
  *  \param keys_last  The end of the input key range.

--- a/thrust/transform_scan.h
+++ b/thrust/transform_scan.h
@@ -51,6 +51,8 @@ THRUST_NAMESPACE_BEGIN
  *  assigned to <tt>\*(result + 1)</tt>, and so on.  The transform scan
  *  operation is permitted to be in-place.
  *
+ *  Results from this function may vary from run to run depending on the inputs provided.
+ *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
  *  \param exec The execution policy to use for parallelization.
@@ -121,6 +123,8 @@ __host__ __device__
  *  assigned to <tt>\*(result + 1)</tt>, and so on.  The transform scan
  *  operation is permitted to be in-place.
  *
+ *  Results from this function may vary from run to run depending on the inputs provided.
+ *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.
  *  \param result The beginning of the output sequence.
@@ -180,6 +184,8 @@ template<typename InputIterator,
  *  and the result of <tt>binary_op(init, unary_op(\*first))</tt> is assigned
  *  to <tt>\*(result + 1)</tt>, and so on.  The transform scan operation is 
  *  permitted to be in-place.
+ *
+ *  Results from this function may vary from run to run depending on the inputs provided.
  *
  *  The algorithm's execution is parallelized as determined by \p exec.
  *
@@ -254,6 +260,8 @@ __host__ __device__
  *  and the result of <tt>binary_op(init, unary_op(\*first))</tt> is assigned
  *  to <tt>\*(result + 1)</tt>, and so on.  The transform scan operation is 
  *  permitted to be in-place.
+ *
+ *  Results from this function may vary from run to run depending on the inputs provided.
  *
  *  \param first The beginning of the input sequence.
  *  \param last The end of the input sequence.


### PR DESCRIPTION
The documentation details which rocThrust API functions are not bitwise reproducible by design.