### PR TITLE
Enable external CI pipeline triggers

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -1,0 +1,48 @@
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+  paths:
+    exclude:
+    - .githooks
+    - .github
+    - .jenkins
+    - doc
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - LICENSE
+    - NOTICES.txt
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - develop
+  paths:
+    exclude:
+    - .githooks
+    - .github
+    - .jenkins
+    - doc
+    - docs
+    - '.*.y*ml'
+    - '*.md'
+    - LICENSE
+    - NOTICES.txt
+  drafts: false
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/rocThrust.yml@pipelines_repo


### PR DESCRIPTION
For build triggers in public-facing CI project on Azure Pipelines: https://dev.azure.com/ROCm-CI/ROCm-CI/_build