### PR TITLE
Fix broken link in API

### DIFF
--- a/thrust/functional.h
+++ b/thrust/functional.h
@@ -1646,7 +1646,7 @@ struct binary_negate
  *  \return A new object, <tt>npred</tt> such that <tt>npred(x,y)</tt> always returns
  *          the same value as <tt>!pred(x,y)</tt>.
  *
- *  \tparam Binary Predicate is a model of <a href="https://en.cppreference.com/w/cpp/utility/functional/AdaptableBinaryPredicate">Adaptable Binary Predicate</a>.
+ *  \tparam Binary Predicate is a model of <a href="https://en.cppreference.com/w/cpp/utility/functional/binary_negate">Adaptable Binary Predicate</a>.
  *
  *  \see binary_negate
  *  \see not1


### PR DESCRIPTION
This fix adjusts the link to Adaptable Binary Predicate in cpp_api.html. The old link doesn't work anymore, so it now points to https://en.cppreference.com/w/cpp/utility/functional/binary_negate. This follows the model of Adaptable Predicate linking to the unary negate page.