### PR TITLE
Temporarily disable scan tests, re-enable tests on gfx11xx

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -32,12 +32,8 @@ def runTestCommand (platform, project)
 
     def testCommand = "ctest --output-on-failure"
     def hmmTestCommand = ''
-    def excludeRegex = 'reduce_by_key.hip'
-
-    if (platform.jenkinsLabel.contains('gfx11'))
-    {
-        excludeRegex = /(reduce_by_key.hip|partition.hip|sort.hip|sort_by_key.hip|stable_sort_by_key.hip|stable_sort.hip|async_copy.hip|async_reduce.hip|async_scan.hip|async_sort.hip|async_transform.hip)/
-    }
+    // Note: temporarily disable scan tests below while waiting for a compiler fix
+    def excludeRegex = /(reduce_by_key.hip|scan)/
     testCommandExclude = "--exclude-regex \"${excludeRegex}\""
 
     if (platform.jenkinsLabel.contains('gfx90a'))

--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -229,7 +229,6 @@ template <class T> struct is_const_or_const_ref<T const> : std::true_type{};
 #endif
 
 // std::invoke from C++17
-// https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
 __thrust_exec_check_disable__
 template <typename Fn, typename... Args,
 #ifdef THRUST_OPTIONAL_LIBCXX_MEM_FN_WORKAROUND
@@ -336,7 +335,6 @@ template <class T, class U = T> struct is_swappable : std::true_type {};
 
 template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
 #else
-// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
 namespace swap_adl_tests {
 // if swap ADL finds this then it would call std::swap otherwise (same
 // signature)


### PR DESCRIPTION
Remove code that excludes gfx11xx tests on Jenkins, since they work there now. Add a temporary exclusion for test_thrust_scan, which needs a compiler fix.