### PR TITLE
Specify minimum version for Google benchmark

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -112,9 +112,10 @@ endif()
 
 # Benchmark dependencies
 if(BUILD_BENCHMARKS)
+  set(BENCHMARK_VERSION 1.8.0)
   if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
     # Google Benchmark (https://github.com/google/benchmark.git)
-    find_package(benchmark QUIET)
+    find_package(benchmark ${BENCHMARK_VERSION} QUIET)
   else()
     message(STATUS "Force installing Google Benchmark.")
   endif()
@@ -137,7 +138,7 @@ if(BUILD_BENCHMARKS)
     download_project(
       PROJ                googlebenchmark
       GIT_REPOSITORY      https://github.com/google/benchmark.git
-      GIT_TAG             v1.8.0
+      GIT_TAG             v${BENCHMARK_VERSION}
       INSTALL_DIR         ${GOOGLEBENCHMARK_ROOT}
       CMAKE_ARGS          -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DBUILD_SHARED_LIBS=OFF -DBENCHMARK_ENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DCMAKE_CXX_STANDARD=14 ${COMPILER_OVERRIDE}
       LOG_DOWNLOAD        TRUE

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core==1.6.2
+rocm-docs-core==1.7.1

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -92,7 +92,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.6.2
+rocm-docs-core==1.7.1
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb

--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -229,7 +229,6 @@ template <class T> struct is_const_or_const_ref<T const> : std::true_type{};
 #endif
 
 // std::invoke from C++17
-// https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
 __thrust_exec_check_disable__
 template <typename Fn, typename... Args,
 #ifdef THRUST_OPTIONAL_LIBCXX_MEM_FN_WORKAROUND
@@ -336,7 +335,6 @@ template <class T, class U = T> struct is_swappable : std::true_type {};
 
 template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
 #else
-// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
 namespace swap_adl_tests {
 // if swap ADL finds this then it would call std::swap otherwise (same
 // signature)


### PR DESCRIPTION
Pass a minimum version to find_package to prevent it from using outdated versions of Google benchmark that may be present on the system.