### PR TITLE
Remove Thrust comments referencing website (cherry-picked from develop)

### DIFF
--- a/thrust/optional.h
+++ b/thrust/optional.h
@@ -229,7 +229,6 @@ template <class T> struct is_const_or_const_ref<T const> : std::true_type{};
 #endif
 
 // std::invoke from C++17
-// https://stackoverflow.com/questions/38288042/c11-14-invoke-workaround
 __thrust_exec_check_disable__
 template <typename Fn, typename... Args,
 #ifdef THRUST_OPTIONAL_LIBCXX_MEM_FN_WORKAROUND
@@ -336,7 +335,6 @@ template <class T, class U = T> struct is_swappable : std::true_type {};
 
 template <class T, class U = T> struct is_nothrow_swappable : std::true_type {};
 #else
-// https://stackoverflow.com/questions/26744589/what-is-a-proper-way-to-implement-is-swappable-to-test-for-the-swappable-concept
 namespace swap_adl_tests {
 // if swap ADL finds this then it would call std::swap otherwise (same
 // signature)


### PR DESCRIPTION
Referencing or using code from some websites is prohibited in rocThrust. Some comments with these kinds of references were recently added by Thrust, and then when we updated the API, were brought into rocThrust. This change removes the references in the comments.