### PR TITLE
Add checks around some platform-specific benchmark code

### DIFF
--- a/benchmarks/bench_utils/generation_utils.hpp
+++ b/benchmarks/bench_utils/generation_utils.hpp
@@ -187,10 +187,15 @@ namespace detail
     template <typename T>
     struct random_to_item_t<T, typename std::enable_if<!std::is_floating_point<T>::value>::type>
     {
+#if THRUST_BENCHMARKS_HAVE_INT128_SUPPORT
         using CastT = typename std::conditional<
             std::is_same<T, int128_t>::value || std::is_same<T, uint128_t>::value,
             typename std::conditional<std::is_signed<T>::value, long, unsigned long>::type,
             T>::type;
+#else
+        using CastT = typename std::conditional<std::is_signed<T>::value, long, unsigned long>::type;
+#endif
+
 
         double m_min;
         double m_max;

--- a/internal/benchmark/timer.h
+++ b/internal/benchmark/timer.h
@@ -3,6 +3,50 @@
 #include <thrust/detail/config.h>
 
 #include <cassert>
+
+#if(THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || defined(_WIN32))
+#include <windows.h>
+
+class steady_timer
+{
+    LARGE_INTEGER start_;
+    LARGE_INTEGER stop_;
+    LARGE_INTEGER frequency_; // Cached to avoid system calls.
+
+ public:
+    steady_timer() : start_(), stop_(), frequency_()
+    {
+        BOOL const r = QueryPerformanceFrequency(&frequency_);
+        assert(0 != r);
+        (void)r; // Silence unused variable 'r' in Release builds, when
+                 // the assertion evaporates.
+    }
+
+    void start()
+    {
+        BOOL const r = QueryPerformanceCounter(&start_);
+        assert(0 != r);
+        (void)r; // Silence unused variable 'r' in Release builds, when
+                 // the assertion evaporates.
+    }
+
+
+    void stop()
+    {
+        BOOL const r = QueryPerformanceCounter(&stop_);
+        assert(0 != r);
+        (void)r; // Silence unused variable 'r' in Release builds, when
+                 // the assertion evaporates.
+    }
+
+    double seconds_elapsed()
+    {
+        return double(stop_.QuadPart - start_.QuadPart)
+             / double(frequency_.QuadPart);
+    }
+};
+
+#else
 #include <time.h>
 
 class steady_timer
@@ -35,3 +79,4 @@ class steady_timer
              + double(stop_.tv_nsec - start_.tv_nsec) * 1.0e-9;
     }
 };
+#endif


### PR DESCRIPTION
There were two spots in the new benchmark code that were causing compile-time issues on some Windows systems. This change adds a check to make sure we have 128-bit integer support before using int128_t in generation_utils.hpp. It also avoids calling clock_gettime on Windows, since it seems to be causing build issues there. Instead, I've restored the old Windows timing code from prior to PR #431, which uses QueryPerformanceFrequency/Counter instead.