### PR TITLE
Fix version numbers in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Documentation for rocThrust available at
 * Split the contents of HIPSTDPAR's forwarding header into several implementation headers.
 * Fixed `copy_if` to work with large data types (512 bytes)
 
-## rocThrust 3.2.0 for ROCm 6.3
+## rocThrust 3.3.0 for ROCm 6.3
 
 ### Added
 
@@ -44,6 +44,12 @@ Documentation for rocThrust available at
 * Fixed an issue in `rmake.py` where the list storing cmake options would contain individual characters instead of a full string of options.
 * Fixed the HIP backend not passing `TestCopyIfNonTrivial` from the upstream (thrust) test suite.
 * Fixed tests failing when compiled with `-D_GLIBCXX_ASSERTIONS=ON`.
+
+## rocThrust 3.1.1 for ROCm 6.2.4
+
+### Added
+
+* gfx1151 support
 
 ## rocThrust 3.1.0 for ROCm 6.2
 


### PR DESCRIPTION
- Add entry for ROCm 6.2.4 from 6.2 release branch https://github.com/ROCm/rocThrust/blob/release/rocm-rel-6.2/CHANGELOG.md

- Fix package version (should be `3.3.0` instead of `3.2.0`) in CHANGELOG.md for ROCm 6.3

https://github.com/ROCm/rocThrust/blob/c33822fe39245a478027effa0acd2039a4c0567c/CMakeLists.txt#L132


@stanleytsang-amd - probably need to update the version accordingly for ROCm 6.4... `3.4.0`?
