### PR TITLE
use jenkins xml instead of hard coded node details

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -38,9 +38,26 @@ def runCI =
 
 ci: { 
     String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
+    def propertyList = ["compute-rocm-dkms-no-npi-hipclang":[pipelineTriggers([cron('0 1 * * 0')])],
+                        "rocm-docker":[]]
+    propertyList = auxiliary.appendPropertyList(propertyList)
 
-    properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * 6')])]))
-    stage(urlJobName) {
-        runCI([ubuntu20:['any']], urlJobName)
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":[]]
+    jobNameList = auxiliary.appendJobNameList(jobNameList)
+
+    propertyList.each
+    {
+        jobName, property->
+        if (urlJobName == jobName)
+            properties(auxiliary.addCommonProperties(property))
+    }
+
+    jobNameList.each
+    {
+        jobName, nodeDetails->
+        if (urlJobName == jobName)
+            stage(jobName) {
+                runCI(nodeDetails, jobName)
+            }
     }
 }


### PR DESCRIPTION
Math-ci woud like to control what nodes static analysis jobs run on.