### PR TITLE
[TBB][cmake][rocThrust] Build TBB if TBB does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Documentation for rocThrust available at
 
 ### Added
 
+* Added a section to install Thread Building Block (TBB) inside `cmake/Dependencies.cmake` if TBB is not already available.
 * Added extended tests to `rtest.py`. These tests are extra tests that did not fit the criteria of smoke and regression tests. These tests will take much longer to run relative to smoke and regression tests. Use `python rtest.py [--emulation|-e|--test|-t]=extended` to run these tests.
 * Added regression tests to `rtest.py`. These tests recreate scenarios that have caused hardware problems in past emulation environments. Use `python rtest.py [--emulation|-e|--test|-t]=regression` to run these tests.
 * Added smoke test options, which runs a subset of the unit tests and ensures that less than 2gb of VRAM will be used. Use `python rtest.py [--emulation|-e|--test|-t]=smoke` to run these tests.

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -39,6 +39,7 @@ if(BUILD_TEST)
   if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
     # Google Test (https://github.com/google/googletest)
     find_package(GTest QUIET)
+    find_package(TBB QUIET)
   else()
     message(STATUS "Force installing GTest.")
   endif()
@@ -61,6 +62,27 @@ if(BUILD_TEST)
       UPDATE_DISCONNECTED TRUE
     )
     find_package(GTest REQUIRED CONFIG PATHS ${GTEST_ROOT})
+  endif()
+
+  if (NOT TARGET TBB:tbb AND NOT TARGET tbb)
+    message(STATUS "TBB not found or force download TBB on. Downloading and building TBB.")
+    set(TBB_ROOT ${CMAKE_CURRENT_BINARY_DIR}/deps/tbb CACHE PATH "" FORCE)
+
+    download_project(
+      PROJ  TBB
+      GIT_REPOSITORY      https://github.com/oneapi-src/oneTBB.git
+      GIT_TAG             1c4c93fc5398c4a1acb3492c02db4699f3048dea # v2021.13.0
+      INSTALL_DIR         ${TBB_ROOT}
+      CMAKE_ARGS          -DCMAKE_CXX_COMPILER=g++ -DTBB_TEST=OFF -DTBB_BUILD=ON -DTBB_INSTALL=ON -DTBBMALLOC_PROXY_BUILD=OFF -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+      LOG_DOWNLOAD        TRUE
+      LOG_CONFIGURE       TRUE
+      LOG_BUILD           TRUE
+      LOG_INSTALL         TRUE
+      BUILD_PROJECT       TRUE
+      UPDATE_DISCONNECTED TRUE
+    )
+    find_package(TBB REQUIRED CONFIG PATHS ${TBB_ROOT})
+  
   endif()
 
   # SQlite (for run-to-run bitwise-reproducibility tests)

--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -10,14 +10,12 @@ if(${DL_ARGS_BUILD_PROJECT})
     ExternalProject_Add(${DL_ARGS_PROJ}-download
                         ${DL_ARGS_UNPARSED_ARGUMENTS}
                         SOURCE_DIR          "${DL_ARGS_SOURCE_DIR}"
-                        BUILD_IN_SOURCE     TRUE
                         TEST_COMMAND        ""
     )
 else()
     ExternalProject_Add(${DL_ARGS_PROJ}-download
                         ${DL_ARGS_UNPARSED_ARGUMENTS}
                         SOURCE_DIR          "${DL_ARGS_SOURCE_DIR}"
-                        BUILD_IN_SOURCE     TRUE
                         TEST_COMMAND        ""
                         UPDATE_COMMAND      ""
                         CONFIGURE_COMMAND   ""

--- a/test/hipstdpar/CMakeLists.txt
+++ b/test/hipstdpar/CMakeLists.txt
@@ -79,21 +79,6 @@ set(ROCTHRUST_CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD 17)
 
 # Dependencies
-find_package(TBB QUIET)
-if(NOT TARGET TBB::tbb AND NOT TARGET tbb)
-    message(STATUS "Thread Building Blocks not found. Fetching...")
-    FetchContent_Declare(
-        thread-building-blocks
-        GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
-        GIT_TAG        1c4c93fc5398c4a1acb3492c02db4699f3048dea # v2021.13.0
-    )
-    # Disable tests for TBB
-    set(TBB_TEST OFF CACHE BOOL "Disable TBB tests" FORCE)
-
-    FetchContent_MakeAvailable(thread-building-blocks)
-else()
-    find_package(TBB REQUIRED)
-endif()
 find_package(Threads REQUIRED)
 
 # Define where to find rocThrust and hipstdpar headers


### PR DESCRIPTION
The original FetchContent_Declare code would cause compilation error.  This is because hipcc cannot compile oneTBB v2021.13.0 and cannot compile v2022.0.0. Since FetchConentent_Declare ignores config steps its not possible to set the CXX compiler for oneTBB and thus a compilation error occurs at build time.

By using downloadProject, a wrapper for ExtrernalProject_Add its possible to declare the CXX compiler and build/install it during config time. 