### PR TITLE
Separate CMake BUILD_TEST and BUILD_HIPSTDPAR_TEST options

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ When compiling with the proper flags (see [LLVM (AMD's fork) docs](https://githu
 HIPSTDPAR is currently packaged along rocThrust. The `hipstdpar` package is set up as a virtual package provided by `rocthrust`, so the latter needs to be installed entirely for getting HIPSTDPAR's headers. Conversely, installing the `rocthrust` package will also include HIPSTDPAR's headers in the system.
 
 ### Tests
-rocThrust also includes some tests for checking the correct building of HIPSTDPAR implementations. These are located under the [tests/hipstdpar](/test/hipstdpar/) folder. When configuring the project with the `BUILD_TEST` option on, these tests will not be enabled by default. To enable them, please set `BUILD_HIPSTDPAR_TEST=ON`. Additionally, one can configure **only** HIPSTDPAR's tests by disabling `BUILD_TEST` and enabling `BUILD_HIPSTDPAR_TEST`. In general, the following steps can be followed for building and running the tests:
+rocThrust also includes tests to check the correct building of HIPSTDPAR implementations. They are located in the [tests/hipstdpar](/test/hipstdpar/) folder. When configuring the project with the `BUILD_TEST` option, these tests will not be enabled by default. To enable them, set `BUILD_HIPSTDPAR_TEST=ON`. Additionally, you can configure only HIPSTDPAR's tests by disabling `BUILD_TEST` and enabling `BUILD_HIPSTDPAR_TEST`. In general, the following steps can be followed for building and running the tests:
 
 ```sh
 git clone https://github.com/ROCm/rocThrust

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ When compiling with the proper flags (see [LLVM (AMD's fork) docs](https://githu
 HIPSTDPAR is currently packaged along rocThrust. The `hipstdpar` package is set up as a virtual package provided by `rocthrust`, so the latter needs to be installed entirely for getting HIPSTDPAR's headers. Conversely, installing the `rocthrust` package will also include HIPSTDPAR's headers in the system.
 
 ### Tests
-rocThrust also includes some tests for checking the correct building of HIPSTDPAR implementations. These are located under the [tests/hipstdpar](/test/hipstdpar/) folder. When configuring the project with the `BUILD_TEST` option on, these tests will also be enabled. Additionally, one can configure **only** HIPSTDPAR's tests by disabling `BUILD_TEST` and enabling `BUILD_HIPSTDPAR_TEST`. In general, the following steps can be followed for building and running the tests:
+rocThrust also includes some tests for checking the correct building of HIPSTDPAR implementations. These are located under the [tests/hipstdpar](/test/hipstdpar/) folder. When configuring the project with the `BUILD_TEST` option on, these tests will not be enabled by default. To enable them, please set `BUILD_HIPSTDPAR_TEST=ON`. Additionally, one can configure **only** HIPSTDPAR's tests by disabling `BUILD_TEST` and enabling `BUILD_HIPSTDPAR_TEST`. In general, the following steps can be followed for building and running the tests:
 
 ```sh
 git clone https://github.com/ROCm/rocThrust
@@ -289,7 +289,8 @@ git clone https://github.com/ROCm/rocThrust
 cd rocThrust; mkdir build; cd build
 
 # Configure rocThrust.
-[CXX=hipcc] cmake ../. -D BUILD_TEST=ON # Configure rocThrust's and HIPSTDPAR's tests.
+[CXX=hipcc] cmake ../. -D BUILD_TEST=ON # Configure rocThrust's tests.
+[CXX=hipcc] cmake ../. -D BUILD_TEST=ON -D BUILD_HIPSTDPAR_TEST=ON # Configure both rocThrust's tests and HIPSTDPAR's tests.
 [CXX=hipcc] cmake ../. -D BUILD_TEST=OFF -D BUILD_HIPSTDPAR_TEST=ON # Only configure HIPSTDPAR's tests.
 
 # Build

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,7 +249,7 @@ if(BUILD_TEST)
 endif()
 
 # hipstdpar tests
-if(BUILD_TEST OR BUILD_HIPSTDPAR_TEST)
+if(BUILD_HIPSTDPAR_TEST)
     if(WIN32)
         message(
             STATUS


### PR DESCRIPTION
Previously, enabling BUILD_TEST would also enable hipstdpar tests if we detected that a c++17-capable compiler was present. However, this caused build issues on systems with a c++17 compiler but an outdated version of libstdc++ that didn't support c++17 (RHEL 8.x).

Currently, we require a minimum cmake version of 3.10.2. There's no real robust way of detecting the libstdc++ version that will work that far back.

To workaround this problem for now, this change splits the BUILD_TEST and BUILD_HIPSTDPAR_TEST cmake options so that they are independent. This means that in order to enable hipstdpar tests, the user must explicitly enable the BUILD_HIPSTDPAR_TEST option.

Update the readme to reflect this.