### PR TITLE
Update google benchmark version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Documentation for rocThrust available at
 [https://rocm.docs.amd.com/projects/rocThrust/en/latest/](https://rocm.docs.amd.com/projects/rocThrust/en/latest/).
 
+## rocThrust 3.5.0 for ROCm 7.0
+
+### Changed
+
+* Updated the required version of Google Benchmark from 1.8.0 to 1.9.0.
+
 ## rocThrust 3.4.0 for ROCm 6.5
 
 ### Added

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -135,7 +135,7 @@ endif()
 
 # Benchmark dependencies
 if(BUILD_BENCHMARKS)
-  set(BENCHMARK_VERSION 1.8.0)
+  set(BENCHMARK_VERSION 1.9.0)
   if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
     # Google Benchmark (https://github.com/google/benchmark.git)
     find_package(benchmark ${BENCHMARK_VERSION} QUIET)


### PR DESCRIPTION
We are now using some newer google benchmark features that are not present in 1.8.0. Update the cmake dependencies file to pull version 1.9.0.