### PR TITLE
Temporarily disable test with bug

### DIFF
--- a/test/test_reproducibility.cpp
+++ b/test/test_reproducibility.cpp
@@ -172,6 +172,16 @@ TYPED_TEST(ReproducibilityTests, ScanByKey)
 
     Policy policy;
 
+    hipStream_t                  stream = thrust::hip_rocprim::stream(policy);
+    rocprim::detail::target_arch target_arch;
+    HIP_CHECK(rocprim::detail::host_target_arch(stream, target_arch));
+
+    if ((target_arch == rocprim::detail::target_arch::gfx1100 || target_arch == rocprim::detail::target_arch::gfx1102)
+        && std::is_same<int, T>::value)
+    {
+      GTEST_SKIP() << "Temporarily skip this test until bug for gfx1100 is fixed.";
+    }
+
     for(auto size : get_sizes())
     {
         SCOPED_TRACE(testing::Message() << "with size= " << size);


### PR DESCRIPTION
Disable failing test, because of bug. Related to https://github.com/ROCm/rocPRIM/pull/735.