### PR TITLE
Update rocThrust package description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PR
 
 rocm_create_package(
   NAME rocthrust
-  DESCRIPTION "Radeon Open Compute Thrust library"
+  DESCRIPTION "rocThrust is a ROCm port of the Thrust library, written in HIP"
   MAINTAINER "rocthrust-maintainer@amd.com"
   HEADER_ONLY
 )


### PR DESCRIPTION
This change updates the cmake description field in CMakeLists.txt to satisfy the current static analysis check's word scan requirements.