### PR TITLE
Restore default scan accumulator type behaviour

### DIFF
--- a/thrust/system/hip/detail/scan.h
+++ b/thrust/system/hip/detail/scan.h
@@ -90,7 +90,12 @@ namespace __scan
                                                            bool              debug_sync)
         -> std::enable_if_t<decltype(nondeterministic(policy))::value, hipError_t>
     {
-        return rocprim::inclusive_scan(
+        return rocprim::inclusive_scan<
+            rocprim::default_config,
+            InputIt,
+            OutputIt,
+            ScanOp,
+            typename std::iterator_traits<InputIt>::value_type>(
             temporary_storage, storage_size, input, output, num_items, scan_op, stream, debug_sync);
     }
 
@@ -106,7 +111,12 @@ namespace __scan
                                                            bool              debug_sync)
         -> std::enable_if_t<!decltype(nondeterministic(policy))::value, hipError_t>
     {
-        return rocprim::deterministic_inclusive_scan(
+        return rocprim::deterministic_inclusive_scan<
+            rocprim::default_config,
+            InputIt,
+            OutputIt,
+            ScanOp,
+            typename std::iterator_traits<InputIt>::value_type>(
             temporary_storage, storage_size, input, output, num_items, scan_op, stream, debug_sync);
     }
 
@@ -180,15 +190,21 @@ namespace __scan
                                                            bool              debug_sync)
         -> std::enable_if_t<decltype(nondeterministic(policy))::value, hipError_t>
     {
-        return rocprim::exclusive_scan(temporary_storage,
-                                       storage_size,
-                                       input,
-                                       output,
-                                       init,
-                                       num_items,
-                                       scan_op,
-                                       stream,
-                                       debug_sync);
+        return rocprim::exclusive_scan<
+            rocprim::default_config,
+            InputIt,
+            OutputIt,
+            T,
+            ScanOp,
+            T>(temporary_storage,
+               storage_size,
+               input,
+               output,
+               init,
+               num_items,
+               scan_op,
+               stream,
+               debug_sync);
     }
 
     template <typename Derived,
@@ -209,15 +225,21 @@ namespace __scan
                                                            bool              debug_sync)
         -> std::enable_if_t<!decltype(nondeterministic(policy))::value, hipError_t>
     {
-        return rocprim::deterministic_exclusive_scan(temporary_storage,
-                                                     storage_size,
-                                                     input,
-                                                     output,
-                                                     init,
-                                                     num_items,
-                                                     scan_op,
-                                                     stream,
-                                                     debug_sync);
+        return rocprim::deterministic_exclusive_scan<
+            rocprim::default_config,
+            InputIt,
+            OutputIt,
+            T,
+            ScanOp,
+            T>(temporary_storage,
+               storage_size,
+               input,
+               output,
+               init,
+               num_items,
+               scan_op,
+               stream,
+               debug_sync);
     }
 
     template <typename Derived, typename InputIt, typename OutputIt, typename Size, typename T, typename ScanOp>


### PR DESCRIPTION
Recently, we changed rocPRIM's default scan accumulator type. Instead of defaulting to the input type (for inclusive scan) or the initial value type (for exclusive scan), it now defaults to the return type of the binary scan operator.
Since rocThrust's scan functions do not explicitly specify the accumulator type, their behaviour changes along with the recent rocPRIM changes. Specifically, it changes in scenarios where mixed input/output types are used in a scan.

This change restores rocThrust's previous behaviour by explicitly passing the appropriate accumulator type (rocPRIM's previous default) as a template argument when calling rocPRIM's scan routines.