### PR TITLE
Update google benchmark version (#545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Documentation for rocThrust available at
 * `--test|-t` is no longer a required flag for `rtest.py`. Instead, the user can use either `--emulation|-e` or `--test|-t`, but not both.
 * Split the contents of HIPSTDPAR's forwarding header into several implementation headers.
 * Fixed `copy_if` to work with large data types (512 bytes)
+* Updated the required version of Google Benchmark from 1.8.0 to 1.9.0.
 
 ### Known Issues
 *  `thrust::inclusive_scan_by_key` might produce incorrect results when it's used with -O2 or -O3 optimization.  

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -134,7 +134,7 @@ endif()
 
 # Benchmark dependencies
 if(BUILD_BENCHMARKS)
-  set(BENCHMARK_VERSION 1.8.0)
+  set(BENCHMARK_VERSION 1.9.0)
   if(NOT DEPENDENCIES_FORCE_DOWNLOAD)
     # Google Benchmark (https://github.com/google/benchmark.git)
     find_package(benchmark ${BENCHMARK_VERSION} QUIET)


### PR DESCRIPTION
We are now using some newer google benchmark features that are not present in 1.8.0. Update the cmake dependencies file to pull version 1.9.0.